### PR TITLE
s3: add permission for ELB logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ module "observe_collection" {
 | [aws_cloudwatch_event_rule.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_log_group.group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_policy.allow_cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -4,40 +4,5 @@ resource "aws_cloudtrail" "trail" {
   s3_key_prefix  = var.s3_exported_prefix
 
   is_multi_region_trail = var.cloudtrail_is_multi_region_trail
-  depends_on            = [aws_s3_bucket_policy.allow_cloudtrail]
-}
-
-resource "aws_s3_bucket_policy" "allow_cloudtrail" {
-  bucket = aws_s3_bucket.bucket.id
-
-  policy = <<-EOF
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Sid": "AWSCloudTrailAclCheck",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "cloudtrail.amazonaws.com"
-              },
-              "Action": "s3:GetBucketAcl",
-              "Resource": "${aws_s3_bucket.bucket.arn}"
-          },
-          {
-              "Sid": "AWSCloudTrailWrite",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "cloudtrail.amazonaws.com"
-              },
-              "Action": "s3:PutObject",
-              "Resource": "${aws_s3_bucket.bucket.arn}/${var.s3_exported_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
-              "Condition": {
-                  "StringEquals": {
-                      "s3:x-amz-acl": "bucket-owner-full-control"
-                  }
-              }
-          }
-      ]
-  }
-EOF
+  depends_on            = [aws_s3_bucket_policy.s3_policy]
 }

--- a/elb.tf
+++ b/elb.tf
@@ -1,0 +1,31 @@
+locals {
+  # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+  elb_account_ids = {
+    us-east-1      = "127311923021"
+    us-east-2      = "033677994240"
+    us-west-1      = "027434742980"
+    us-west-2      = "797873946194"
+    af-south-1     = "098369216593"
+    ca-central-1   = "985666609251"
+    eu-central-1   = "054676820928"
+    eu-west-1      = "156460612806"
+    eu-west-2      = "652711504416"
+    eu-south-1     = "635631232127"
+    eu-west-3      = "009996457667"
+    eu-north-1     = "897822967062"
+    ap-east-1      = "754344448648"
+    ap-northeast-1 = "582318560864"
+    ap-northeast-2 = "600734575887"
+    ap-northeast-3 = "383597477331"
+    ap-southeast-1 = "114774131450"
+    ap-southeast-2 = "783225319266"
+    ap-south-1     = "718504428378"
+    me-south-1     = "076674570225"
+    sa-east-1      = "507241528517"
+    us-gov-west-1  = "048591011584"
+    us-gov-east-1  = "190560391635"
+    cn-north-1     = "638102146993"
+    cn-northwest-1 = "037604701340"
+  }
+}
+

--- a/main.tf
+++ b/main.tf
@@ -4,4 +4,6 @@ locals {
   subscribed_log_group_names_firehose = var.cloudwatch_logs_subscribe_to_firehose ? var.subscribed_log_group_names : []
 }
 
+data "aws_region" "current" {}
+
 data "aws_caller_identity" "current" {}

--- a/s3.tf
+++ b/s3.tf
@@ -27,3 +27,61 @@ module "observe_lambda_s3_bucket_subscription" {
   iam_name_prefix = local.name_prefix
   filter_prefix   = var.s3_exported_prefix
 }
+
+
+data "aws_iam_policy_document" "s3_policy" {
+
+  statement {
+    sid     = "AclCheck"
+    actions = ["s3:GetBucketAcl"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    resources = [
+      aws_s3_bucket.bucket.arn,
+    ]
+  }
+
+  statement {
+    sid     = "PutObject"
+    actions = ["s3:PutObject"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${lookup(local.elb_account_ids, data.aws_region.current.name, "missing")}:root"]
+    }
+
+    resources = [
+      "${aws_s3_bucket.bucket.arn}/${var.s3_exported_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "s3_policy" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}


### PR DESCRIPTION
We can't hook ELB logs up for you, but we can ensure that the
appropriate permissions are configured.