### PR TITLE
fix: remove action variable, allow falling back to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ module "observe_collection" {
 | <a name="module_observe_firehose_cloudwatch_logs_subscription"></a> [observe\_firehose\_cloudwatch\_logs\_subscription](#module\_observe\_firehose\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.3.0//cloudwatch_logs_subscription |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.3.0//eventbridge |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.3.0 |
-| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | github.com/observeinc/terraform-aws-lambda | v0.9.0 |
-| <a name="module_observe_lambda_cloudwatch_logs_subscription"></a> [observe\_lambda\_cloudwatch\_logs\_subscription](#module\_observe\_lambda\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-lambda | v0.9.0//cloudwatch_logs_subscription |
-| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | github.com/observeinc/terraform-aws-lambda | v0.9.0//s3_bucket_subscription |
-| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | github.com/observeinc/terraform-aws-lambda | v0.9.0//snapshot |
+| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | github.com/observeinc/terraform-aws-lambda | v0.10.0 |
+| <a name="module_observe_lambda_cloudwatch_logs_subscription"></a> [observe\_lambda\_cloudwatch\_logs\_subscription](#module\_observe\_lambda\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-lambda | v0.10.0//cloudwatch_logs_subscription |
+| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | github.com/observeinc/terraform-aws-lambda | v0.10.0//s3_bucket_subscription |
+| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | github.com/observeinc/terraform-aws-lambda | v0.10.0//snapshot |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.6.0 |
 
 ## Resources
@@ -124,8 +124,8 @@ module "observe_collection" {
 | <a name="input_s3_exported_prefix"></a> [s3\_exported\_prefix](#input\_s3\_exported\_prefix) | Key prefix which is subscribed to be sent to Observe Lambda | `string` | `""` | no |
 | <a name="input_s3_lifecycle_rule"></a> [s3\_lifecycle\_rule](#input\_s3\_lifecycle\_rule) | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_s3_logging"></a> [s3\_logging](#input\_s3\_logging) | Enable S3 access log collection | `bool` | `false` | no |
-| <a name="input_snapshot_action"></a> [snapshot\_action](#input\_snapshot\_action) | List of actions allowed by policy and periodically triggered. | `list(string)` | <pre>[<br>  "autoscaling:Describe*",<br>  "cloudformation:Describe*",<br>  "cloudfront:List*",<br>  "dynamodb:Describe*",<br>  "dynamodb:List*",<br>  "ec2:Describe*",<br>  "ecs:Describe*",<br>  "ecs:List*",<br>  "elasticache:Describe*",<br>  "elasticloadbalancing:Describe*",<br>  "events:List*",<br>  "firehose:Describe*",<br>  "firehose:List*",<br>  "iam:Get*",<br>  "iam:List*",<br>  "kinesis:Describe*",<br>  "kinesis:List*",<br>  "kms:Describe*",<br>  "kms:List*",<br>  "lambda:List*",<br>  "logs:Describe*",<br>  "organizations:Describe*",<br>  "organizations:List*",<br>  "rds:Describe*",<br>  "redshift:Describe*",<br>  "route53:List*",<br>  "s3:GetBucket*",<br>  "s3:List*",<br>  "secretsmanager:List*",<br>  "sns:Get*",<br>  "sns:List*",<br>  "sqs:Get*",<br>  "sqs:List*"<br>]</pre> | no |
 | <a name="input_snapshot_exclude"></a> [snapshot\_exclude](#input\_snapshot\_exclude) | List of actions to exclude from being executed on snapshot request. | `list(string)` | `[]` | no |
+| <a name="input_snapshot_include"></a> [snapshot\_include](#input\_snapshot\_include) | List of actions to include in snapshot request. | `list(string)` | `[]` | no |
 | <a name="input_subscribed_log_group_names"></a> [subscribed\_log\_group\_names](#input\_subscribed\_log\_group\_names) | Log groups to subscribe to | `list(string)` | `[]` | no |
 | <a name="input_subscribed_s3_bucket_arns"></a> [subscribed\_s3\_bucket\_arns](#input\_subscribed\_s3\_bucket\_arns) | List of additional S3 bucket ARNs to subscribe lambda to. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 module "observe_lambda" {
-  source = "github.com/observeinc/terraform-aws-lambda?ref=v0.9.0"
+  source = "github.com/observeinc/terraform-aws-lambda?ref=v0.10.0"
 
   name             = var.name
   observe_domain   = var.observe_domain
@@ -16,7 +16,7 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_cloudwatch_logs_subscription" {
-  source = "github.com/observeinc/terraform-aws-lambda?ref=v0.9.0//cloudwatch_logs_subscription"
+  source = "github.com/observeinc/terraform-aws-lambda?ref=v0.10.0//cloudwatch_logs_subscription"
   lambda = module.observe_lambda.lambda_function
 
   allow_all_log_groups = true
@@ -31,9 +31,9 @@ module "observe_lambda_cloudwatch_logs_subscription" {
 }
 
 module "observe_lambda_snapshot" {
-  source                  = "github.com/observeinc/terraform-aws-lambda?ref=v0.9.0//snapshot"
+  source                  = "github.com/observeinc/terraform-aws-lambda?ref=v0.10.0//snapshot"
   lambda                  = module.observe_lambda
   eventbridge_name_prefix = local.name_prefix
-  action                  = var.snapshot_action
+  include                 = var.snapshot_include
   exclude                 = var.snapshot_exclude
 }

--- a/s3.tf
+++ b/s3.tf
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "bucket" {
 }
 
 module "observe_lambda_s3_bucket_subscription" {
-  source          = "github.com/observeinc/terraform-aws-lambda?ref=v0.9.0//s3_bucket_subscription"
+  source          = "github.com/observeinc/terraform-aws-lambda?ref=v0.10.0//s3_bucket_subscription"
   lambda          = module.observe_lambda.lambda_function
   bucket_arns     = concat([local.s3_bucket.arn], var.subscribed_s3_bucket_arns)
   iam_name_prefix = local.name_prefix

--- a/variables.tf
+++ b/variables.tf
@@ -108,44 +108,10 @@ variable "s3_lifecycle_rule" {
   default     = []
 }
 
-variable "snapshot_action" {
-  description = "List of actions allowed by policy and periodically triggered."
+variable "snapshot_include" {
+  description = "List of actions to include in snapshot request."
   type        = list(string)
-  default = [
-    "autoscaling:Describe*",
-    "cloudformation:Describe*",
-    "cloudfront:List*",
-    "dynamodb:Describe*",
-    "dynamodb:List*",
-    "ec2:Describe*",
-    "ecs:Describe*",
-    "ecs:List*",
-    "elasticache:Describe*",
-    "elasticloadbalancing:Describe*",
-    "events:List*",
-    "firehose:Describe*",
-    "firehose:List*",
-    "iam:Get*",
-    "iam:List*",
-    "kinesis:Describe*",
-    "kinesis:List*",
-    "kms:Describe*",
-    "kms:List*",
-    "lambda:List*",
-    "logs:Describe*",
-    "organizations:Describe*",
-    "organizations:List*",
-    "rds:Describe*",
-    "redshift:Describe*",
-    "route53:List*",
-    "s3:GetBucket*",
-    "s3:List*",
-    "secretsmanager:List*",
-    "sns:Get*",
-    "sns:List*",
-    "sqs:Get*",
-    "sqs:List*",
-  ]
+  default     = []
 }
 
 variable "snapshot_exclude" {


### PR DESCRIPTION
We update the default actions list implicitly every time we bump the
version of the `terraform-aws-lambda` module. Rather than keep tabs on
what actions are supported in two separate modules, always fall back to
whatever the underlying lambda module supports.

In practice this change breaks backward compatibility, but there is no
loss of functionality. The `snapshot_include` and `snapshot_exclude`
variables can be used to tailor the list of actions if needed.