### PR TITLE
feat: use new log group subscription module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ module "observe_collection" {
 }
 ```
 
+## Common Options
+
+The snippet below installs the Observe AWS collection stack so that all supported
+CloudWatch Logs, CloudWatch metrics, CloudTrail records, and AWS resource updates
+are collected, except for some excluded items:
+
+```
+module "observe_collection" {
+  source           = "github.com/observeinc/terraform-aws-collection"
+  observe_customer = ""
+  observe_token    = ""
+  subscribed_log_group_matches = [".*"]
+
+  subscribed_log_group_excludes = ["/aws/lambda/elasticbeanstalk/my-app.*"]
+  snapshot_exclude = ["kms:Describe*"]
+  cloudwatch_metrics_exclude_filters = ["AWS/KMS"]
+}
+```
+
 # Diagram
 
      ┌──────────────────┐                          ┌───────────────┐    ┌─────────────┐
@@ -132,7 +151,7 @@ module "observe_collection" {
 | <a name="input_snapshot_schedule_expression"></a> [snapshot\_schedule\_expression](#input\_snapshot\_schedule\_expression) | Rate at which snapshot is triggered. Must be valid EventBridge expression | `string` | `"rate(3 hours)"` | no |
 | <a name="input_subscribed_log_group_excludes"></a> [subscribed\_log\_group\_excludes](#input\_subscribed\_log\_group\_excludes) | A list of regex patterns describing CloudWatch log groups to NOT subscribe to.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_excludes for more info" | `list(string)` | `[]` | no |
 | <a name="input_subscribed_log_group_filter_pattern"></a> [subscribed\_log\_group\_filter\_pattern](#input\_subscribed\_log\_group\_filter\_pattern) | A filter pattern for a CloudWatch Logs subscription filter.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_filter_pattern or<br>https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for more info" | `string` | `""` | no |
-| <a name="input_subscribed_log_group_matches"></a> [subscribed\_log\_group\_matches](#input\_subscribed\_log\_group\_matches) | A list of regex patterns describing CloudWatch log groups to subscribe to.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_matches for more info" | `list(string)` | <pre>[<br>  ".*"<br>]</pre> | no |
+| <a name="input_subscribed_log_group_matches"></a> [subscribed\_log\_group\_matches](#input\_subscribed\_log\_group\_matches) | A list of regex patterns describing CloudWatch log groups to subscribe to.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_matches for more info" | `list(string)` | `[]` | no |
 | <a name="input_subscribed_log_group_names"></a> [subscribed\_log\_group\_names](#input\_subscribed\_log\_group\_names) | Log groups to subscribe to. This is deprecated. Prefer subscribed\_log\_group\_matches | `list(string)` | `[]` | no |
 | <a name="input_subscribed_s3_bucket_arns"></a> [subscribed\_s3\_bucket\_arns](#input\_subscribed\_s3\_bucket\_arns) | List of additional S3 bucket ARNs to subscribe lambda to. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ module "observe_collection" {
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-cloudwatch-logs-subscription | v0.2.0 |
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//cloudwatch_metrics |
-| <a name="module_observe_firehose_cloudwatch_logs_subscription"></a> [observe\_firehose\_cloudwatch\_logs\_subscription](#module\_observe\_firehose\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//cloudwatch_logs_subscription |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//eventbridge |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | github.com/observeinc/terraform-aws-lambda | v0.13.0 |
@@ -96,7 +96,7 @@ module "observe_collection" {
 |------|------|
 | [aws_cloudtrail.trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_event_rule.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_log_group.group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -110,7 +110,7 @@ module "observe_collection" {
 | <a name="input_cloudtrail_enable_log_file_validation"></a> [cloudtrail\_enable\_log\_file\_validation](#input\_cloudtrail\_enable\_log\_file\_validation) | Whether log file integrity validation is enabled for CloudTrail. Defalults to false. | `bool` | `false` | no |
 | <a name="input_cloudtrail_is_multi_region_trail"></a> [cloudtrail\_is\_multi\_region\_trail](#input\_cloudtrail\_is\_multi\_region\_trail) | Whether to enable multi region trail export | `bool` | `true` | no |
 | <a name="input_cloudwatch_logs_subscribe_to_firehose"></a> [cloudwatch\_logs\_subscribe\_to\_firehose](#input\_cloudwatch\_logs\_subscribe\_to\_firehose) | Subscribe cloudwatch logs to firehose | `bool` | `true` | no |
-| <a name="input_cloudwatch_logs_subscribe_to_lambda"></a> [cloudwatch\_logs\_subscribe\_to\_lambda](#input\_cloudwatch\_logs\_subscribe\_to\_lambda) | Subscribe cloudwatch logs to Lambda | `bool` | `false` | no |
+| <a name="input_cloudwatch_logs_subscribe_to_lambda"></a> [cloudwatch\_logs\_subscribe\_to\_lambda](#input\_cloudwatch\_logs\_subscribe\_to\_lambda) | Subscribe cloudwatch logs to Lambda. This is deprecated. | `bool` | `false` | no |
 | <a name="input_cloudwatch_metrics_exclude_filters"></a> [cloudwatch\_metrics\_exclude\_filters](#input\_cloudwatch\_metrics\_exclude\_filters) | Namespaces to exclude. Mutually exclusive with cloudwatch\_metrics\_include\_filters. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_metrics_include_filters"></a> [cloudwatch\_metrics\_include\_filters](#input\_cloudwatch\_metrics\_include\_filters) | Namespaces to include. Mutually exclusive with cloudwatch\_metrics\_exclude\_filters. | `list(string)` | `[]` | no |
 | <a name="input_dead_letter_queue_destination"></a> [dead\_letter\_queue\_destination](#input\_dead\_letter\_queue\_destination) | Send failed events/function executions to a dead letter queue arn sns or sqs | `string` | `null` | no |
@@ -130,7 +130,10 @@ module "observe_collection" {
 | <a name="input_snapshot_exclude"></a> [snapshot\_exclude](#input\_snapshot\_exclude) | List of actions to exclude from being executed on snapshot request. | `list(string)` | `[]` | no |
 | <a name="input_snapshot_include"></a> [snapshot\_include](#input\_snapshot\_include) | List of actions to include in snapshot request. | `list(string)` | `[]` | no |
 | <a name="input_snapshot_schedule_expression"></a> [snapshot\_schedule\_expression](#input\_snapshot\_schedule\_expression) | Rate at which snapshot is triggered. Must be valid EventBridge expression | `string` | `"rate(3 hours)"` | no |
-| <a name="input_subscribed_log_group_names"></a> [subscribed\_log\_group\_names](#input\_subscribed\_log\_group\_names) | Log groups to subscribe to | `list(string)` | `[]` | no |
+| <a name="input_subscribed_log_group_excludes"></a> [subscribed\_log\_group\_excludes](#input\_subscribed\_log\_group\_excludes) | A list of regex patterns describing CloudWatch log groups to NOT subscribe to.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_excludes for more info" | `list(string)` | `[]` | no |
+| <a name="input_subscribed_log_group_filter_pattern"></a> [subscribed\_log\_group\_filter\_pattern](#input\_subscribed\_log\_group\_filter\_pattern) | A filter pattern for a CloudWatch Logs subscription filter.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_filter_pattern or<br>https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for more info" | `string` | `""` | no |
+| <a name="input_subscribed_log_group_matches"></a> [subscribed\_log\_group\_matches](#input\_subscribed\_log\_group\_matches) | A list of regex patterns describing CloudWatch log groups to subscribe to.<br><br>See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_matches for more info" | `list(string)` | <pre>[<br>  ".*"<br>]</pre> | no |
+| <a name="input_subscribed_log_group_names"></a> [subscribed\_log\_group\_names](#input\_subscribed\_log\_group\_names) | Log groups to subscribe to. This is deprecated. Prefer subscribed\_log\_group\_matches | `list(string)` | `[]` | no |
 | <a name="input_subscribed_s3_bucket_arns"></a> [subscribed\_s3\_bucket\_arns](#input\_subscribed\_s3\_bucket\_arns) | List of additional S3 bucket ARNs to subscribe lambda to. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module "observe_collection" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-cloudwatch-logs-subscription | v0.2.0 |
+| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.2.0 |
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//cloudwatch_metrics |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//eventbridge |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0 |
@@ -115,7 +115,7 @@ module "observe_collection" {
 |------|------|
 | [aws_cloudtrail.trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_event_rule.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_log_group.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_log_group" "group" {
+resource "aws_cloudwatch_log_group" "firehose" {
   name              = format("/aws/firehose/%s", var.name)
   retention_in_days = var.retention_in_days
 }
@@ -14,7 +14,7 @@ module "observe_kinesis_firehose" {
   iam_name_prefix                  = local.name_prefix
   s3_delivery_bucket               = local.s3_bucket
   http_endpoint_buffering_interval = 60
-  cloudwatch_log_group             = aws_cloudwatch_log_group.group
+  cloudwatch_log_group             = aws_cloudwatch_log_group.firehose
   tags                             = var.tags
 }
 
@@ -27,11 +27,3 @@ module "observe_cloudwatch_metrics" {
   exclude_filters  = var.cloudwatch_metrics_exclude_filters
 }
 
-module "observe_firehose_cloudwatch_logs_subscription" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose?ref=v0.4.0//cloudwatch_logs_subscription"
-  kinesis_firehose = module.observe_kinesis_firehose
-  iam_name_prefix  = local.name_prefix
-  log_group_names = concat(local.subscribed_log_group_names_firehose, [
-    format("/aws/lambda/%s", var.name)
-  ])
-}

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_log_group" "firehose" {
+resource "aws_cloudwatch_log_group" "group" {
   name              = format("/aws/firehose/%s", var.name)
   retention_in_days = var.retention_in_days
 }
@@ -14,7 +14,7 @@ module "observe_kinesis_firehose" {
   iam_name_prefix                  = local.name_prefix
   s3_delivery_bucket               = local.s3_bucket
   http_endpoint_buffering_interval = 60
-  cloudwatch_log_group             = aws_cloudwatch_log_group.firehose
+  cloudwatch_log_group             = aws_cloudwatch_log_group.group
   tags                             = var.tags
 }
 

--- a/lambda.tf
+++ b/lambda.tf
@@ -18,15 +18,15 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_cloudwatch_logs_subscription" {
+  count = length(local.subscribed_log_group_names_lambda) > 0 ? 1 : 0
+
   source = "github.com/observeinc/terraform-aws-lambda?ref=v0.13.0//cloudwatch_logs_subscription"
   lambda = module.observe_lambda.lambda_function
 
   allow_all_log_groups = true
 
   statement_id_prefix = local.name_prefix
-  log_group_names = concat(local.subscribed_log_group_names_lambda, [
-    aws_cloudwatch_log_group.group.name
-  ])
+  log_group_names     = local.subscribed_log_group_names_lambda
 
   # avoid racing with s3 bucket subscription
   depends_on = [module.observe_lambda_s3_bucket_subscription]

--- a/subscription.tf
+++ b/subscription.tf
@@ -1,5 +1,6 @@
 module "observe_cloudwatch_logs_subscription" {
-  source           = "github.com/observeinc/terraform-aws-cloudwatch-logs-subscription?ref=v0.2.0"
+  source           = "observeinc/cloudwatch-logs-subscription/aws"
+  version          = "0.2.0"
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix
 
@@ -7,7 +8,7 @@ module "observe_cloudwatch_logs_subscription" {
   filter_pattern = var.subscribed_log_group_filter_pattern
 
   log_group_matches = concat(
-    [aws_cloudwatch_log_group.firehose.name, format("/aws/lambda/%s", var.name)], # Note: Data from firehose will go to itself. There is a cycle.
+    [aws_cloudwatch_log_group.group.name, format("/aws/lambda/%s", var.name)], # Note: Data from firehose will go to itself. There is a cycle.
     var.subscribed_log_group_matches,
     local.subscribed_log_group_names_firehose,
   )

--- a/subscription.tf
+++ b/subscription.tf
@@ -1,0 +1,20 @@
+module "observe_cloudwatch_logs_subscription" {
+  source           = "github.com/observeinc/terraform-aws-cloudwatch-logs-subscription?ref=v0.2.0"
+  kinesis_firehose = module.observe_kinesis_firehose
+  iam_name_prefix  = local.name_prefix
+
+  filter_name    = var.name
+  filter_pattern = var.subscribed_log_group_filter_pattern
+
+  log_group_matches = concat(
+    [aws_cloudwatch_log_group.firehose.name, format("/aws/lambda/%s", var.name)], # Note: Data from firehose will go to itself. There is a cycle.
+    var.subscribed_log_group_matches,
+    local.subscribed_log_group_names_firehose,
+  )
+  log_group_excludes = var.subscribed_log_group_excludes
+
+  # avoid racing with s3 bucket subscription
+  depends_on = [
+    module.observe_lambda_s3_bucket_subscription
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,16 +60,46 @@ variable "dead_letter_queue_destination" {
 }
 
 variable "subscribed_log_group_names" {
-  description = "Log groups to subscribe to"
+  description = "Log groups to subscribe to. This is deprecated. Prefer subscribed_log_group_matches"
   type        = list(string)
   default     = []
 }
-
 
 variable "subscribed_s3_bucket_arns" {
   description = "List of additional S3 bucket ARNs to subscribe lambda to."
   type        = list(string)
   default     = []
+}
+
+variable "subscribed_log_group_matches" {
+  description = <<-EOF
+    A list of regex patterns describing CloudWatch log groups to subscribe to.
+
+    See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_matches for more info"
+  EOF
+  type        = list(string)
+  default     = [".*"]
+}
+
+variable "subscribed_log_group_excludes" {
+  description = <<-EOF
+    A list of regex patterns describing CloudWatch log groups to NOT subscribe to.
+
+    See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_excludes for more info"
+  EOF
+  type        = list(string)
+  default     = []
+}
+
+variable "subscribed_log_group_filter_pattern" {
+  description = <<-EOF
+    A filter pattern for a CloudWatch Logs subscription filter.
+
+    See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_filter_pattern or
+    https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for more info"
+  EOF
+  type        = string
+  default     = ""
 }
 
 variable "tags" {
@@ -85,7 +115,7 @@ variable "cloudwatch_logs_subscribe_to_firehose" {
 }
 
 variable "cloudwatch_logs_subscribe_to_lambda" {
-  description = "Subscribe cloudwatch logs to Lambda"
+  description = "Subscribe cloudwatch logs to Lambda. This is deprecated."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "subscribed_log_group_matches" {
     See https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription#input_log_group_matches for more info"
   EOF
   type        = list(string)
-  default     = [".*"]
+  default     = []
 }
 
 variable "subscribed_log_group_excludes" {


### PR DESCRIPTION
This change replaces the old cloudwatch logs subscription with the new stuff in https://github.com/observeinc/terraform-aws-cloudwatch-logs-subscription.

This exposes a few new variables and removes the subscribe-to-lambda variable.

Testing: Successfully applied in Thunderdome.