### PR TITLE
feat!: bump lambda, kinesis-firehose modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ module "observe_collection" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.2.0 |
-| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//cloudwatch_metrics |
-| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0//eventbridge |
-| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | github.com/observeinc/terraform-aws-kinesis-firehose | v0.4.0 |
-| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | github.com/observeinc/terraform-aws-lambda | v0.13.0 |
-| <a name="module_observe_lambda_cloudwatch_logs_subscription"></a> [observe\_lambda\_cloudwatch\_logs\_subscription](#module\_observe\_lambda\_cloudwatch\_logs\_subscription) | github.com/observeinc/terraform-aws-lambda | v0.13.0//cloudwatch_logs_subscription |
-| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | github.com/observeinc/terraform-aws-lambda | v0.13.0//s3_bucket_subscription |
-| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | github.com/observeinc/terraform-aws-lambda | v0.13.0//snapshot |
+| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 1.0.0 |
+| <a name="module_observe_firehose_cloudwatch_logs_subscription"></a> [observe\_firehose\_cloudwatch\_logs\_subscription](#module\_observe\_firehose\_cloudwatch\_logs\_subscription) | observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription | 1.0.0 |
+| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 1.0.0 |
+| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 1.0.0 |
+| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 1.0.0 |
+| <a name="module_observe_lambda_cloudwatch_logs_subscription"></a> [observe\_lambda\_cloudwatch\_logs\_subscription](#module\_observe\_lambda\_cloudwatch\_logs\_subscription) | observeinc/lambda/aws//modules/cloudwatch_logs_subscription | 1.0.0 |
+| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 1.0.0 |
+| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 1.0.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.6.0 |
 
 ## Resources

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -7,7 +7,9 @@ resource "aws_cloudwatch_event_rule" "wildcard" {
 }
 
 module "observe_firehose_eventbridge" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose?ref=v0.4.0//eventbridge"
+  source  = "observeinc/kinesis-firehose/aws//modules/eventbridge"
+  version = "1.0.0"
+
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix
   rules = [

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,6 @@
 module "observe_lambda" {
-  source = "github.com/observeinc/terraform-aws-lambda?ref=v0.13.0"
+  source  = "observeinc/lambda/aws"
+  version = "1.0.0"
 
   name             = var.name
   observe_domain   = var.observe_domain
@@ -20,8 +21,9 @@ module "observe_lambda" {
 module "observe_lambda_cloudwatch_logs_subscription" {
   count = length(local.subscribed_log_group_names_lambda) > 0 ? 1 : 0
 
-  source = "github.com/observeinc/terraform-aws-lambda?ref=v0.13.0//cloudwatch_logs_subscription"
-  lambda = module.observe_lambda.lambda_function
+  source  = "observeinc/lambda/aws//modules/cloudwatch_logs_subscription"
+  version = "1.0.0"
+  lambda  = module.observe_lambda.lambda_function
 
   allow_all_log_groups = true
 
@@ -33,7 +35,9 @@ module "observe_lambda_cloudwatch_logs_subscription" {
 }
 
 module "observe_lambda_snapshot" {
-  source                          = "github.com/observeinc/terraform-aws-lambda?ref=v0.13.0//snapshot"
+  source  = "observeinc/lambda/aws//modules/snapshot"
+  version = "1.0.0"
+
   lambda                          = module.observe_lambda
   eventbridge_name_prefix         = local.name_prefix
   eventbridge_schedule_expression = var.snapshot_schedule_expression

--- a/s3.tf
+++ b/s3.tf
@@ -177,7 +177,9 @@ data "aws_iam_policy_document" "bucket" {
 }
 
 module "observe_lambda_s3_bucket_subscription" {
-  source          = "github.com/observeinc/terraform-aws-lambda?ref=v0.13.0//s3_bucket_subscription"
+  source  = "observeinc/lambda/aws//modules/s3_bucket_subscription"
+  version = "1.0.0"
+
   lambda          = module.observe_lambda.lambda_function
   bucket_arns     = concat([local.s3_bucket.arn], var.subscribed_s3_bucket_arns)
   iam_name_prefix = local.name_prefix

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "observe_customer" {
 variable "observe_token" {
   description = "Observe Token"
   type        = string
+
+  validation {
+    condition     = contains(split("", var.observe_token), ":")
+    error_message = "Token format does not follow {datastream_id}:{datastream_secret} format."
+  }
 }
 
 variable "observe_domain" {


### PR DESCRIPTION
BREAKING CHANGE: `observe_token` must now be in
`{datastream_token_id}:{datastream_token_secret}` format.