### PR TITLE
fix: pass name into observe_cloudwatch_logs_subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ module "observe_collection" {
 | <a name="input_lambda_reserved_concurrent_executions"></a> [lambda\_reserved\_concurrent\_executions](#input\_lambda\_reserved\_concurrent\_executions) | The number of simultaneous executions to reserve for the function. | `number` | `100` | no |
 | <a name="input_lambda_s3_custom_rules"></a> [lambda\_s3\_custom\_rules](#input\_lambda\_s3\_custom\_rules) | List of rules to evaluate how to upload a given S3 object to Observe. | <pre>list(object({<br>    pattern = string<br>    headers = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Lambda version | `string` | `"latest"` | no |
+| <a name="input_log_subscription_name"></a> [log\_subscription\_name](#input\_log\_subscription\_name) | Name for log subscription resources to be created | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for resources to be created | `string` | `"observe-collection"` | no |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
 | <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |

--- a/subscription.tf
+++ b/subscription.tf
@@ -1,6 +1,8 @@
 module "observe_cloudwatch_logs_subscription" {
-  source           = "observeinc/cloudwatch-logs-subscription/aws"
-  version          = "0.4.0"
+  source  = "observeinc/cloudwatch-logs-subscription/aws"
+  version = "0.4.0"
+
+  name             = var.log_subscription_name
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "name" {
   default     = "observe-collection"
 }
 
+variable "log_subscription_name" {
+  description = "Name for log subscription resources to be created"
+  type        = string
+  default     = null
+}
+
 variable "observe_customer" {
   description = "Observe Customer ID"
   type        = string


### PR DESCRIPTION
## What does this PR do?

This fixes an issue where one could not install multiple terraform-aws-collection modules in the same region.

## Testing

I tested by installing terraform-aws-collection in Thunderdome.