### PR TITLE
fix: pass tags into subscription submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module "observe_collection" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.2.0 |
+| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.4.0 |
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 1.0.2 |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 1.0.2 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 1.0.2 |

--- a/subscription.tf
+++ b/subscription.tf
@@ -1,6 +1,6 @@
 module "observe_cloudwatch_logs_subscription" {
   source           = "observeinc/cloudwatch-logs-subscription/aws"
-  version          = "0.2.0"
+  version          = "0.4.0"
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix
 
@@ -17,4 +17,6 @@ module "observe_cloudwatch_logs_subscription" {
   depends_on = [
     module.observe_lambda_s3_bucket_subscription
   ]
+
+  tags = var.tags
 }


### PR DESCRIPTION
## What does this PR do?

This closes https://github.com/observeinc/terraform-aws-collection/issues/32 by passing the tags field into a new version of the subscription module.

### Testing

I have tested by applying the terraform-aws-collection module and inspecting the tags.