### PR TITLE
chore: add test terraform module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,14 @@ changelog:
 release:
 	semtag final -s minor
 
+.PHONY: test
 test:
+	pre-commit run
+
+.PHONY: test-single-region
+test-single-region: test
+	cd ./test/ &&	./test.sh
+
+.PHONY: test-all-regions
+test-all-regions: test
+	cd ./test/ &&	./test.sh -a

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ module "observe_collection" {
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.0.0 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.0.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.1.3 |
+| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.1.3 |
+| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.1.3 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.8.2 |
 
 ## Resources
 
@@ -161,6 +164,7 @@ module "observe_collection" {
 | Name | Description |
 |------|-------------|
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | S3 bucket subscribed to Observe Lambda |
+| <a name="output_cloudtrail"></a> [cloudtrail](#output\_cloudtrail) | AWS Cloudtrail. Currently this is experimental and only exposed for the test module. |
 | <a name="output_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#output\_observe\_kinesis\_firehose) | Observe Kinesis Firehose module |
 | <a name="output_observe_lambda"></a> [observe\_lambda](#output\_observe\_lambda) | Observe Lambda module |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "bucket" {
   description = "S3 bucket subscribed to Observe Lambda"
   value       = local.s3_bucket
 }
+
+output "cloudtrail" {
+  description = "AWS Cloudtrail. Currently this is experimental and only exposed for the test module."
+  value       = aws_cloudtrail.trail
+}

--- a/s3.tf
+++ b/s3.tf
@@ -184,7 +184,22 @@ data "aws_iam_policy_document" "bucket" {
 
 }
 
+# TODO(luke): uncomment this in a follow up commit to make terraform-aws-collection
+# more likely to avoid the terraform apply failure
+# (due to s3 bucket notification eventual consistency)
+#
+# resource "time_sleep" "wait_before_subscribing" {
+#   depends_on = module.s3_bucket
+
+#   create_duration = "10s"
+# }
+
 module "observe_lambda_s3_bucket_subscription" {
+  # TODO(luke): uncomment this in a follow up commit to make terraform-aws-collection
+  # more likely to avoid the terraform apply failure
+  # (due to s3 bucket notification eventual consistency)
+  # depends_on = [time_sleep.wait_before_subscribing]
+
   source  = "observeinc/lambda/aws//modules/s3_bucket_subscription"
   version = "3.1.3"
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,92 @@
+# Basic terraform tests. If they break, you probably have introduced a breaking change.
+# These tests cannot catch errors, but can be used to verify that the more complex variables worked as expected.
+
+provider "aws" {}
+
+module "test_defaults" {
+  source                = "../"
+  name                  = "${var.name}-defaults"
+  log_subscription_name = "${var.name}-defaults-logs"
+  observe_customer      = "123"
+  observe_token         = "ds123456789:dogdogdogdog"
+}
+
+locals {
+  result_defaults = {
+    "cloudtrail" : length(module.test_defaults.cloudtrail) > 0,
+  }
+}
+
+module "test_non_defaults" {
+  source = "../"
+
+  name                  = "${var.name}-non-defaults"
+  log_subscription_name = "${var.name}-non-defaults-logs"
+  observe_customer      = "123"
+  observe_token         = "ds123456789:dogdogdogdog"
+
+  lambda_version = "v1.0.20230210"
+  lambda_s3_custom_rules = [{
+    pattern = ".*"
+    headers = {
+      "my-http-header" : "my-http-value"
+    }
+  }]
+  lambda_reserved_concurrent_executions = 10
+  retention_in_days                     = 7
+  lambda_envvars = {
+    "MY_KEY" : "my-value"
+  }
+  # dead_letter_queue_destination = 
+  # subscribed_s3_bucket_arns = 
+
+  subscribed_log_group_matches  = [".*"]
+  subscribed_log_group_excludes = [".*bean.*", ".*nginx.*"]
+
+  tags = {
+    "my-key" = "my-value"
+  }
+
+  # s3_exported_prefix =
+  # s3_logging =
+  # s3_lifecycle_rule = 
+
+  snapshot_include             = ["cloudformation:List*"]
+  snapshot_exclude             = ["kms:List*"]
+  snapshot_schedule_expression = "rate(1 hour)"
+
+  # kms_key_id = 
+
+  # cloudtrail_is_multi_region_trail = 
+  cloudtrail_enable = false
+  # cloudtrail_enable_log_file_validation = 
+  # cloudtrail_exclude_management_event_sources = 
+
+  # cloudwatch_metrics_include_filters = 
+  # cloudwatch_metrics_exclude_filters = 
+}
+
+locals {
+  result_non_defaults = {
+    "cloudtrail" : length(module.test_non_defaults.cloudtrail) == 0,
+    # "tags_bucket" : module.test_module_2.bucket.tags == {"my-key" = "my-value"}
+  }
+}
+
+# tflint-ignore: terraform_standard_module_structure
+output "result" {
+  description = "True of false"
+  value = (
+    alltrue([for k, v in local.result_defaults : v]) &&
+    alltrue([for k, v in local.result_non_defaults : v])
+  )
+}
+
+# tflint-ignore: terraform_standard_module_structure
+output "result_details" {
+  description = "A map of the test statuses"
+  value = {
+    result_defaults     = local.result_defaults
+    result_non_defaults = local.result_non_defaults
+  }
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# The first few lines up to the usage() function are copied from
+# https://github.com/observeinc/manifests/blob/acf66e63cc79e61c1f2882532f9121804c6bb690/scripts/test.sh
+set -o errexit
+set -o pipefail
+
+DIE() { echo "${R}E! $*${r}" 1>&2; exit 1; }
+INFO() { echo "${B}I: $*${r}" 1>&2; }
+DEBUG() { test -z "$VERBOSE" || echo "D: $*" 1>&2; }
+
+R="[1;31m"
+B="[1;34m"
+r="[m"
+
+usage() {
+    echo "${B}$0 [-havs]"
+    echo "  -a     test all regions Observe supports. Note that this takes 30+ minutes."
+    echo "  -v     verbose"
+    echo "  -s     don't call terraform destroy"
+    echo "  -h     this help"
+    echo
+    exit 1
+}
+
+while getopts 'havs' OPTION; do
+    case $OPTION in
+        a) ALL_REGIONS=1 ;;
+        s) SKIP_DESTROY=1 ;;
+        v) VERBOSE=1 ;;
+        *) usage ;;
+    esac
+done
+
+[[ -n "$ALL_REGIONS" ]] && export ALL_REGIONS
+[[ -n "$VERBOSE" ]] && export VERBOSE
+[[ -n "$SKIP_DESTROY" ]] && export SKIP_DESTROY
+
+
+if [[ -n "$ALL_REGIONS" ]]; then
+    regions=("us-east-1"
+        "us-east-2" \
+        "us-west-1" \
+        "us-west-2" \
+        "ap-south-1" \
+        "ap-northeast-1" \
+        "ap-northeast-2" \
+        "ap-northeast-3" \
+        "ap-southeast-1" \
+        "ap-southeast-2" \
+        "eu-central-1" \
+        "eu-west-1" \
+        "eu-west-2" \
+        "eu-west-3" \
+        "eu-north-1" \
+        "sa-east-1")
+else
+    regions=("us-west-2")
+fi
+
+INFO "AWS Profile: ${AWS_PROFILE}"
+INFO "Regions: ${regions[@]}"
+test_module_name=observe-${USER}
+INFO "TF Module Name: ${test_module_name}"
+
+
+AWS_REGION=$region terraform init -no-color
+
+for region in ${regions[@]}; do
+    DEBUG "Testing region $region"
+    export AWS_REGION=$region
+    terraform apply -auto-approve -no-color -var="name=${test_module_name}"
+    terraform output
+    RESULT=$(terraform output -json result)
+    if [ "$RESULT" != "true" ]; then
+        echo "Test failed"
+        exit 1
+    fi
+    if [[ -n "$SKIP_DESTROY" ]]; then
+        echo "Destroy skipped. Please destroy manually."
+    else
+        terraform destroy -auto-approve -no-color -var="name=${test_module_name}"
+    fi
+done

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  type        = string
+  description = "Name"
+}

--- a/test/versions.tf
+++ b/test/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    aws = ">= 3.75"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,13 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0.0"
     }
+
+    # TODO(luke): uncomment this in a follow up commit to make terraform-aws-collection
+    # more likely to avoid the terraform apply failure
+    # (due to s3 bucket notification eventual consistency)
+    # time = {
+    #   source  = "hashicorp/time"
+    #   version = ">= 0.9.1"
+    # }
   }
 }


### PR DESCRIPTION
## What does this PR do?

This changes adds a test terraform module allows us to write some basic tests that inspect the output of successfully-created terraform modules.

## Testing

I ran the tests.