### PR TITLE
fix: set `source` in `required_providers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ module "observe_collection" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >=3.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
-| <a name="provider_random"></a> [random](#provider\_random) | >=3.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,14 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws    = ">= 3.75"
-    random = ">=3.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.75"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Replaces the [legacy `required_providers` declaration](https://developer.hashicorp.com/terraform/language/providers/requirements#v0-12-compatible-provider-requirements) with `{source, version}`.

## Motivation

Fixes warnings about implicit provider selection when passing in a provider instance to the module. Closes #31.

## Limitations

Since Terraform continues to support this syntax for backward compatibility with 0.12, we need to enforce this separately. https://github.com/terraform-linters/tflint-ruleset-terraform/pull/64 will allow us to detect and reject this syntax in the future.

## Testing

I tried to write a test module but was unable to reproduce the originally reported warning on `terraform validate`:

```tf
module "m" {
  source = "../"

  observe_token = "id:secret"
  observe_customer = "12345"

  providers = {
    aws = aws.aliased
   }
}

provider "aws" {
  alias = "aliased"
}
```

Even if there were no reported issue/warning, we should still be setting `source` anyway.