### PR TITLE
chore: add dependabot for Terraform and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What does this PR do?

Enables dependency update PRs for Terraform (providers/modules) and GitHub Actions. 

## Motivation

Important functionality is handled by child modules, with fixed versions:

https://github.com/observeinc/terraform-aws-collection/blob/78a6420b8a60ddca095444d7c778afcd00d3d29e/lambda.tf#L3

Arguably these should be ranges that allow patch updates. But even then, Dependabot is still useful for ensuring these ranges are bumped on new minors.