### PR TITLE
fix!: update cloudwatch logs subscription module

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module "observe_collection" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -99,7 +99,7 @@ module "observe_collection" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.4.0 |
+| <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.5.0 |
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 1.0.3 |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 1.0.3 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 1.0.3 |

--- a/subscription.tf
+++ b/subscription.tf
@@ -1,6 +1,16 @@
+locals {
+  enable_subscription = length(var.subscribed_log_group_matches) + length(var.subscribed_log_group_excludes) > 0
+}
+
+moved {
+  from = module.observe_cloudwatch_logs_subscription
+  to   = module.observe_cloudwatch_logs_subscription[0]
+}
+
 module "observe_cloudwatch_logs_subscription" {
+  count   = local.enable_subscription ? 1 : 0
   source  = "observeinc/cloudwatch-logs-subscription/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   name             = var.log_subscription_name
   kinesis_firehose = module.observe_kinesis_firehose
@@ -9,11 +19,12 @@ module "observe_cloudwatch_logs_subscription" {
   filter_name    = var.name
   filter_pattern = var.subscribed_log_group_filter_pattern
 
-  log_group_matches = concat(
-    [aws_cloudwatch_log_group.group.name, format("/aws/lambda/%s", var.name)], # Note: Data from firehose will go to itself. There is a cycle.
-    var.subscribed_log_group_matches,
+  log_group_matches = var.subscribed_log_group_matches
+  log_group_excludes = concat(
+    var.subscribed_log_group_excludes,
+    # log groups managed by our module should be explicitly subscribed
+    [aws_cloudwatch_log_group.group.name, "/aws/lambda/${var.name}"],
   )
-  log_group_excludes = var.subscribed_log_group_excludes
 
   # avoid racing with s3 bucket subscription
   depends_on = [

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This commit bumps the cloudwatch logs subscription module and gates it conditionally on the `subscribed_log_group_matches` and `subscribed_log_group_excludes` variables. If neither list is provided, the module will not be installed.

To retain the implicit behavior from 1.X versions, users can explicitly provide log groups, e.g:

```
module "observe_collection" {
  source           = "observeinc/collection/aws"
  name             = var.name
  observe_customer = "<customer_id>"
  observe_token    = "<secret>"

  # subscribe created log groups to Observe firehose
  subscribed_log_group_matches = [
    "/aws/lambda/${var.name}",
    "/aws/firehose/${var.name}",
  ]
}
```

As a result of these changes, the minimum terraform provider version is now 1.1.0. This is matches the requirements of the underyling cloudwatch logs subscription module, and allows the usage of `moved` directive to retain existing cloudwatch log subscription modules across upgrades.
