### PR TITLE
fix: respect cloudtrail configuration in eventbridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ module "observe_collection" {
 | Name | Type |
 |------|------|
 | [aws_cloudtrail.trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
+| [aws_cloudwatch_event_rule.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_log_group.group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -1,8 +1,23 @@
 resource "aws_cloudwatch_event_rule" "wildcard" {
   name_prefix = local.name_prefix
-  description = "Capture all events in account"
+  description = "Capture all events except CloudTrail in account"
   event_pattern = jsonencode({
     "account" : [data.aws_caller_identity.current.account_id]
+    "detail-type" : [{ "anything-but" : "AWS API Call via CloudTrail" }]
+  })
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_rule" "cloudtrail" {
+  count       = var.cloudtrail_enable ? 1 : 0
+  name_prefix = local.name_prefix
+  description = "Capture all CloudTrail events in account"
+  event_pattern = jsonencode({
+    "account" : [data.aws_caller_identity.current.account_id]
+    "detail-type" : ["AWS API Call via CloudTrail"]
+    "detail" : {
+      "eventSource" : [{ "anything-but" : var.cloudtrail_exclude_management_event_sources }]
+    }
   })
   tags = var.tags
 }
@@ -13,8 +28,9 @@ module "observe_firehose_eventbridge" {
 
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix
-  rules = [
-    aws_cloudwatch_event_rule.wildcard,
-  ]
+  rules = concat(
+    [aws_cloudwatch_event_rule.wildcard],
+    aws_cloudwatch_event_rule.cloudtrail,
+  )
   tags = var.tags
 }


### PR DESCRIPTION
This commit ensures that we take into account user preferences for cloudtrail when forwarding events from eventbridge.

Cloudtrail events are available on the default event bus. Previously, all cloudtrail events would be forwarded to Observe, independently of the value of `enable_cloudtrail` or
`cloudtrail_exclude_management_event_sources`, which encode user preferences for Cloudtrail.

We break the existing eventbridge rule in two:
- a rule that matches all events _other_ than Cloudtrail
- a rule that matches all Cloudtrail excluding management events in exclusion list. This rule is only created if `enable_cloudtrail` is true.