### PR TITLE
feat: allow overriding eventbridge rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ module "observe_collection" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.5.0 |
-| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 1.0.3 |
-| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 1.0.3 |
-| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 1.0.3 |
+| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.0.0 |
+| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.0.0 |
+| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.0.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 1.1.2 |
 | <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 1.1.2 |
 | <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 1.1.2 |
@@ -113,7 +113,7 @@ module "observe_collection" {
 | Name | Type |
 |------|------|
 | [aws_cloudtrail.trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
-| [aws_cloudwatch_event_rule.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_log_group.group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -132,6 +132,7 @@ module "observe_collection" {
 | <a name="input_cloudwatch_metrics_exclude_filters"></a> [cloudwatch\_metrics\_exclude\_filters](#input\_cloudwatch\_metrics\_exclude\_filters) | Namespaces to exclude. Mutually exclusive with cloudwatch\_metrics\_include\_filters. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_metrics_include_filters"></a> [cloudwatch\_metrics\_include\_filters](#input\_cloudwatch\_metrics\_include\_filters) | Namespaces to include. Mutually exclusive with cloudwatch\_metrics\_exclude\_filters. | `list(string)` | `[]` | no |
 | <a name="input_dead_letter_queue_destination"></a> [dead\_letter\_queue\_destination](#input\_dead\_letter\_queue\_destination) | Send failed events/function executions to a dead letter queue arn sns or sqs | `string` | `null` | no |
+| <a name="input_eventbridge_rules"></a> [eventbridge\_rules](#input\_eventbridge\_rules) | Eventbridge events matching these rules will be forwarded to Observe. Map<br>keys are only used to provide stable resource addresses.<br><br>If null, a default set of rules will be used. | <pre>map(object({<br>    description   = string<br>    event_pattern = string<br>  }))</pre> | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key ARN to use to encrypt the logs delivered by CloudTrail. | `string` | `""` | no |
 | <a name="input_lambda_envvars"></a> [lambda\_envvars](#input\_lambda\_envvars) | Environment variables | `map(any)` | `{}` | no |
 | <a name="input_lambda_reserved_concurrent_executions"></a> [lambda\_reserved\_concurrent\_executions](#input\_lambda\_reserved\_concurrent\_executions) | The number of simultaneous executions to reserve for the function. | `number` | `100` | no |

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -1,20 +1,44 @@
-resource "aws_cloudwatch_event_rule" "wildcard" {
-  name_prefix = local.name_prefix
-  description = "Capture all events in account"
-  event_pattern = jsonencode({
-    "account" : [data.aws_caller_identity.current.account_id]
+locals {
+  eventbridge_rules = coalesce(var.eventbridge_rules, {
+    wildcard = {
+      description = "Capture all events other than CloudTrail"
+      event_pattern = jsonencode({
+        detail-type = [{ anything-but = "AWS API Call via CloudTrail" }]
+      })
+    },
+    cloudtrail = {
+      description = "Capture all CloudTrail events"
+      event_pattern = jsonencode({
+        detail-type = ["AWS API Call via CloudTrail"]
+        detail = {
+          eventSource = [{ anything-but = var.cloudtrail_exclude_management_event_sources }]
+        }
+      })
+    }
   })
-  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_rule" "rules" {
+  for_each      = local.eventbridge_rules
+  name_prefix   = local.name_prefix
+  description   = each.value.description
+  event_pattern = each.value.event_pattern
+  tags          = var.tags
+}
+
+# prior to 2.x, default rules were always applied
+moved {
+  from = module.observe_firehose_eventbridge
+  to   = module.observe_firehose_eventbridge[0]
 }
 
 module "observe_firehose_eventbridge" {
+  count   = length(aws_cloudwatch_event_rule.rules) > 0 ? 1 : 0
   source  = "observeinc/kinesis-firehose/aws//modules/eventbridge"
-  version = "1.0.3"
+  version = "2.0.0"
 
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix
-  rules = [
-    aws_cloudwatch_event_rule.wildcard,
-  ]
-  tags = var.tags
+  rules            = aws_cloudwatch_event_rule.rules
+  tags             = var.tags
 }

--- a/firehose.tf
+++ b/firehose.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_log_group" "group" {
 
 module "observe_kinesis_firehose" {
   source  = "observeinc/kinesis-firehose/aws"
-  version = "1.0.3"
+  version = "2.0.0"
 
   name             = var.name
   observe_customer = var.observe_customer
@@ -21,7 +21,7 @@ module "observe_kinesis_firehose" {
 
 module "observe_cloudwatch_metrics" {
   source  = "observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics"
-  version = "1.0.3"
+  version = "2.0.0"
 
   name             = var.name
   iam_name_prefix  = local.name_prefix

--- a/variables.tf
+++ b/variables.tf
@@ -202,3 +202,17 @@ variable "cloudwatch_metrics_exclude_filters" {
   type        = list(string)
   default     = []
 }
+
+variable "eventbridge_rules" {
+  description = <<-EOF
+    Eventbridge events matching these rules will be forwarded to Observe. Map
+    keys are only used to provide stable resource addresses.
+
+    If null, a default set of rules will be used.
+  EOF
+  type = map(object({
+    description   = string
+    event_pattern = string
+  }))
+  default = null
+}


### PR DESCRIPTION
This commit changes the set of default patterns we use for forwarding Eventbridge events to Observe. This set can be overridden through the `eventbridge_patterns` variable.

Our default rule set now contains two rules:
- a rule that matches all events _other_ than Cloudtrail
- a rule that matches all Cloudtrail excluding management events in the `cloudtrail_exclude_management_event_sources` list.
