### PR TITLE
feat: introduce `s3_bucket_name` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ module "observe_collection" {
 | <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Retention in days of cloudwatch log group | `number` | `365` | no |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Override the name used for the S3 bucket created by this module.<br><br>If empty, the bucket name will combine the `name` variable with the<br>region and a random suffix to ensure it is globally unique. | `string` | `""` | no |
 | <a name="input_s3_exported_prefix"></a> [s3\_exported\_prefix](#input\_s3\_exported\_prefix) | Key prefix which is subscribed to be sent to Observe Lambda | `string` | `""` | no |
 | <a name="input_s3_lifecycle_rule"></a> [s3\_lifecycle\_rule](#input\_s3\_lifecycle\_rule) | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_s3_logging"></a> [s3\_logging](#input\_s3\_logging) | Enable S3 access log collection | `bool` | `false` | no |

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,5 @@
 locals {
-  bucket_name  = "${local.name_prefix}${data.aws_region.current.name}-${random_string.this.id}"
+  bucket_name  = var.s3_bucket_name != "" ? var.s3_bucket_name : "${local.name_prefix}${data.aws_region.current.name}-${random_string.this[0].id}"
   bucket_arn   = "arn:aws:s3:::${local.bucket_name}"
   aws_logs_arn = "${local.bucket_arn}/${local.s3_exported_prefix}AWSLogs/${data.aws_caller_identity.current.account_id}/*"
 
@@ -10,6 +10,7 @@ locals {
 }
 
 resource "random_string" "this" {
+  count   = var.s3_bucket_name == "" ? 1 : 0
   length  = 8
   upper   = false
   special = false

--- a/variables.tf
+++ b/variables.tf
@@ -242,3 +242,15 @@ variable "eventbridge_rules" {
   }))
   default = null
 }
+
+variable "s3_bucket_name" {
+  description = <<-EOF
+    Override the name used for the S3 bucket created by this module.
+
+    If empty, the bucket name will combine the `name` variable with the
+    region and a random suffix to ensure it is globally unique.
+  EOF
+  type        = string
+  nullable    = false
+  default     = ""
+}


### PR DESCRIPTION
This commit introduces the ability to override the bucket name used for our collection bucket.

By default, we create a bucket name from the concatenation of `name`, `region`, and some random suffix. The fact this is not known at apply time can be a hinderance in some cases, e.g. trying to tag a bucket with its name.