### PR TITLE
fix: adjust bucket ownership to allow ACLs (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ module "observe_collection" {
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.0.0 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.0.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.1.3 |
+| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.1.3 |
+| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.1.3 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.8.2 |
 
 ## Resources
 

--- a/s3.tf
+++ b/s3.tf
@@ -46,6 +46,7 @@ module "s3_bucket" {
     }
   }
 
+  object_ownership        = "BucketOwnerPreferred"
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true


### PR DESCRIPTION
Recent changes to bucket settings flipped defaults (https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-faq.html)

This change incompatible with our existing use of canned ACLs.  To work around this error, we can specify `BucketOwnerPreferred` in cases where we use canned ACLs. Since our existing security posture already disallows public access, this is no different from the new and improved defaults.