### PR TITLE
fix(s3): set object ownership to ObjectWriter

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -46,11 +46,8 @@ module "s3_bucket" {
     }
   }
 
-  object_ownership        = "BucketOwnerPreferred"
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   attach_elb_log_delivery_policy = true
   attach_lb_log_delivery_policy  = true


### PR DESCRIPTION
As of terraform-aws-modules/terraform-aws-s3-bucket 3.9.0 the module now correctly accounts for the new default ACL settings. This commit reflects the latest guidance from the the module docs.
