### PR TITLE
feat(subscription): subscribe to Lambda logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ module "observe_collection" {
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_lambda_log_subscription"></a> [lambda\_log\_subscription](#module\_lambda\_log\_subscription) | observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription | 2.0.2 |
 | <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.5.0 |
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.0.2 |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.0.2 |
@@ -138,6 +139,7 @@ module "observe_collection" {
 | <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation.<br>The default value is 128 MB. The value must be a multiple of 64 MB. | `number` | `128` | no |
 | <a name="input_lambda_reserved_concurrent_executions"></a> [lambda\_reserved\_concurrent\_executions](#input\_lambda\_reserved\_concurrent\_executions) | The number of simultaneous executions to reserve for the function. | `number` | `100` | no |
 | <a name="input_lambda_s3_custom_rules"></a> [lambda\_s3\_custom\_rules](#input\_lambda\_s3\_custom\_rules) | List of rules to evaluate how to upload a given S3 object to Observe. | <pre>list(object({<br>    pattern = string<br>    headers = map(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_lambda_subscribe_logs"></a> [lambda\_subscribe\_logs](#input\_lambda\_subscribe\_logs) | Whether to subscribe to the Lambda function's logs and deliver them from CloudWatch to Observe via Kinesis Firehose. | `bool` | `true` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | The amount of time that Lambda allows a function to run before stopping it.<br>The maximum allowed value is 900 seconds. | `number` | `60` | no |
 | <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Lambda version | `string` | `"latest"` | no |
 | <a name="input_log_subscription_name"></a> [log\_subscription\_name](#input\_log\_subscription\_name) | Name for log subscription resources to be created | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "lambda_reserved_concurrent_executions" {
   default     = 100
 }
 
+variable "lambda_subscribe_logs" {
+  description = "Whether to subscribe to the Lambda function's logs and deliver them from CloudWatch to Observe via Kinesis Firehose."
+  type        = bool
+  default     = true
+}
+
 variable "retention_in_days" {
   description = "Retention in days of cloudwatch log group"
   type        = number


### PR DESCRIPTION
## What does this PR do?

Add a CloudWatch Logs subscription filter for the Observe Lambda's log group, by default, with the option to turn it off via `lambda_subscribe_logs = false`. 

## Motivation

This will send logs generated from the Lambda itself to Observe, aiding debugging issues with the Lambda's code.

## Testing

Validates via `terraform validate`. We've also done E2E testing and see Lambda logs hitting Observe. 