### PR TITLE
chore(outputs): kinesis firehose needs to be considered sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,7 @@ output "observe_lambda" {
 output "observe_kinesis_firehose" {
   description = "Observe Kinesis Firehose module"
   value       = module.observe_kinesis_firehose
+  sensitive   = true
 }
 
 output "bucket" {


### PR DESCRIPTION
## What does this PR do?

Kinesis firehose should be considered sensitive

```
       │ Error: Output refers to sensitive values
       │ 
       │   on outputs.tf line 6:
       │    6: output "observe_kinesis_firehose" {
       │ 
       │ To reduce the risk of accidentally exporting sensitive data that was
       │ intended to be only internal, Terraform requires that any root module
       │ output containing sensitive data be explicitly marked as sensitive, to
       │ confirm your intent.
       │ 
       │ If you do intend to export this data, annotate the output value as
       │ sensitive by adding the following argument:
       │     sensitive = true
```
