### PR TITLE
fix(snapshot): add back organizations:List* to match CloudFormation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,7 @@ variable "snapshot_action" {
     "kinesis:List*",
     "lambda:List*",
     "logs:Describe*",
+    "organizations:List*",
     "rds:Describe*",
     "route53:List*",
     "s3:GetBucket*",


### PR DESCRIPTION
## What does this PR do?

Adds organizations:List* back to the snapshot_action default value, because it's one source of data used in modeling the Accounts resource

## Testing

In progress
