### PR TITLE
feat(config): allow publishing to SNS topic

### DIFF
--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -41,6 +41,7 @@ No modules.
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_policy.service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -48,8 +49,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | The name of the S3 bucket used to store the configuration history. | `string` | n/a | yes |
-| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | The frequency with which AWS Config recurringly delivers configuration snapshots | `string` | `"Three_Hours"` | no |
-| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | Specifies whether AWS Config includes all supported types of global<br>resources with the resources that it records. | `bool` | `true` | no |
+| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | The frequency with which AWS Config recurringly delivers configuration snapshots. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours, TwentyFour\_Hours (https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html). | `string` | `"Three_Hours"` | no |
+| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | Specifies whether AWS Config includes all supported types of global resources with the resources that it records. | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to set on AWS Config resources. | `string` | `"default"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix for the specified S3 bucket. | `string` | `""` | no |
 | <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The ARN of the SNS topic that AWS Config delivers notifications to. | `string` | `null` | no |

--- a/modules/config/iam.tf
+++ b/modules/config/iam.tf
@@ -10,6 +10,14 @@ resource "aws_iam_role" "this" {
     name   = "writer"
     policy = data.aws_iam_policy_document.writer.json
   }
+
+  dynamic "inline_policy" {
+    for_each = var.sns_topic_arn != null ? [1] : []
+    content {
+      name   = "notifications"
+      policy = data.aws_iam_policy_document.notifications.json
+    }
+  }
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -44,6 +52,18 @@ data "aws_iam_policy_document" "writer" {
 
     resources = [
       "arn:aws:s3:::${var.bucket}/${var.prefix}AWSLogs/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "notifications" {
+  statement {
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      var.sns_topic_arn != null ? var.sns_topic_arn : "",
     ]
   }
 }


### PR DESCRIPTION
Allow AWS Config to publish change notifications to a provided SNS topic.

We can not use `count` on `var.sns_topic_arn` to gate the construction of the IAM policy in this case. Terraform will complain it cannot determine the number of instances prior to apply. Instead we always declare a well formed policy, but only inline it if an SNS topic is provided.