### PR TITLE
feat: bump kinesis firehose, s3 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,30 +84,30 @@ module "observe_collection" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda_log_subscription"></a> [lambda\_log\_subscription](#module\_lambda\_log\_subscription) | observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription | 2.1.0 |
+| <a name="module_lambda_log_subscription"></a> [lambda\_log\_subscription](#module\_lambda\_log\_subscription) | observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription | 2.2.0 |
 | <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.5.0 |
-| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.1.0 |
-| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.1.0 |
-| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.1.0 |
+| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.2.0 |
+| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.2.0 |
+| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.2.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.4.0 |
 | <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.4.0 |
 | <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.4.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.15.1 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 
 ## Resources
 
@@ -119,7 +119,6 @@ module "observe_collection" {
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_redshift_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/redshift_service_account) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -35,7 +35,7 @@ moved {
 module "observe_firehose_eventbridge" {
   count   = length(aws_cloudwatch_event_rule.rules) > 0 ? 1 : 0
   source  = "observeinc/kinesis-firehose/aws//modules/eventbridge"
-  version = "2.1.0"
+  version = "2.2.0"
 
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = local.name_prefix

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,6 +1,9 @@
+resource "random_pet" "run" {}
+
 module "observe_collection" {
   #source           = "github.com/observeinc/terraform-aws-collection"
   source           = "../../"
+  name             = random_pet.run.id
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
   observe_domain   = var.observe_domain

--- a/examples/simple/tests/simple.tftest.hcl
+++ b/examples/simple/tests/simple.tftest.hcl
@@ -1,0 +1,6 @@
+run "install" {
+  variables {
+    observe_customer = "1"
+    observe_token    = "dskey:secret"
+  }
+}

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,7 +1,15 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
   }
+
 }

--- a/firehose.tf
+++ b/firehose.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_log_group" "group" {
 
 module "observe_kinesis_firehose" {
   source  = "observeinc/kinesis-firehose/aws"
-  version = "2.1.0"
+  version = "2.2.0"
 
   name             = var.name
   observe_customer = var.observe_customer
@@ -28,7 +28,7 @@ moved {
 module "observe_cloudwatch_metrics" {
   count   = contains(var.cloudwatch_metrics_exclude_filters, "*") ? 0 : 1
   source  = "observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics"
-  version = "2.1.0"
+  version = "2.2.0"
 
   name             = var.name
   iam_name_prefix  = local.name_prefix

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -18,14 +18,14 @@ module "observe_collection" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/forwarder/README.md
+++ b/modules/forwarder/README.md
@@ -57,15 +57,15 @@ module "forwarder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/forwarder/versions.tf
+++ b/modules/forwarder/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75"
+      version = ">= 5.0"
     }
 
     random = {

--- a/s3.tf
+++ b/s3.tf
@@ -25,7 +25,7 @@ moved {
 module "s3_bucket" {
   count   = local.create_s3_bucket ? 1 : 0
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.15.1"
+  version = "~> 4.0"
 
   bucket        = local.bucket_name
   acl           = "log-delivery-write"
@@ -56,8 +56,6 @@ module "s3_bucket" {
 
   tags = var.tags
 }
-
-data "aws_redshift_service_account" "this" {}
 
 data "aws_iam_policy_document" "bucket" {
   statement {
@@ -149,9 +147,10 @@ data "aws_iam_policy_document" "bucket" {
     effect = "Allow"
 
     principals {
-      type        = "AWS"
-      identifiers = [data.aws_redshift_service_account.this.arn]
+      type        = "Service"
+      identifiers = ["redshift.amazonaws.com"]
     }
+
 
     actions = [
       "s3:PutObject",
@@ -167,8 +166,8 @@ data "aws_iam_policy_document" "bucket" {
     effect = "Allow"
 
     principals {
-      type        = "AWS"
-      identifiers = [data.aws_redshift_service_account.this.arn]
+      type        = "Service"
+      identifiers = ["redshift.amazonaws.com"]
     }
 
     actions = [

--- a/subscription.tf
+++ b/subscription.tf
@@ -43,7 +43,7 @@ module "lambda_log_subscription" {
   count = var.lambda_subscribe_logs ? 1 : 0
 
   source  = "observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription"
-  version = "2.1.0"
+  version = "2.2.0"
 
   kinesis_firehose = module.observe_kinesis_firehose
   log_group_names  = [local.lambda_log_group]

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75"
+      version = ">= 5.0"
     }
 
     random = {


### PR DESCRIPTION
Bump modules to latest versions. As a result of these upgrades, the minimum terraform AWS provider is now 5.0.