### PR TITLE
fix(config): add `include_resource_types` and `exclude_resource_types`

### DIFF
--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -6,10 +6,42 @@ This module sets up AWS Config to store configuration data to a provided S3 buck
 
 # Usage
 
-```
-module "observe_collection" {
+```json
+module "config" {
   source = "observeinc/collection/aws//modules/config"
   bucket = "my-example-bucket"
+}
+```
+
+By omission, all resource types are collected, including global resources such as IAM.
+
+To disable collection for global resources, provide `include_global_resource_types`:
+
+```json
+module "config" {
+  source                         = "observeinc/collection/aws//modules/config"
+  bucket                         = "my-example-bucket"
+  include_global_resource_types  = false
+}
+```
+
+You can exclude specific resource types, provide `exclude_resource_types`:
+
+```json
+module "config" {
+  source                  = "observeinc/collection/aws//modules/config"
+  bucket                  = "my-example-bucket"
+  exclude_resource_types  = ["AWS::EC2::Instance"]
+}
+```
+
+To only collect certain resource types, provide `include_resource_types`:
+
+```json
+module "config" {
+  source                  = "observeinc/collection/aws//modules/config"
+  bucket                  = "my-example-bucket"
+  include_resource_types  = ["AWS::EC2::Instance"]
 }
 ```
 
@@ -18,7 +50,7 @@ module "observe_collection" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
@@ -49,8 +81,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | The name of the S3 bucket used to store the configuration history. | `string` | n/a | yes |
-| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | The frequency with which AWS Config recurringly delivers configuration snapshots. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours, TwentyFour\_Hours (https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html). | `string` | `"Three_Hours"` | no |
-| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | Specifies whether AWS Config includes all supported types of global resources with the resources that it records. | `bool` | `true` | no |
+| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | The frequency with which AWS Config recurringly delivers configuration<br>snapshots. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours,<br>TwentyFour\_Hours<br>(https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html)." | `string` | `"Three_Hours"` | no |
+| <a name="input_exclude_resource_types"></a> [exclude\_resource\_types](#input\_exclude\_resource\_types) | Exclude a subset of resource types from configuration collection. This<br>parameter is mutually exclusive with IncludeResourceTypes. | `list(string)` | `[]` | no |
+| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | Specifies whether AWS Config includes all supported types of global<br>resources with the resources that it records. This field only takes<br>effect if all resources are included for collection. include\_resource\_types<br>must be set to *, and exclude\_resource\_types must not be set. | `bool` | `true` | no |
+| <a name="input_include_resource_types"></a> [include\_resource\_types](#input\_include\_resource\_types) | Restrict configuration collection to a subset of resource types. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to set on AWS Config resources. | `string` | `"default"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix for the specified S3 bucket. | `string` | `""` | no |
 | <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The ARN of the SNS topic that AWS Config delivers notifications to. | `string` | `null` | no |

--- a/modules/config/config.tf
+++ b/modules/config/config.tf
@@ -3,8 +3,30 @@ resource "aws_config_configuration_recorder" "this" {
   role_arn = aws_iam_role.this.arn
 
   recording_group {
-    all_supported                 = true
-    include_global_resource_types = var.include_global_resource_types
+    all_supported                 = local.all_supported
+    include_global_resource_types = local.all_supported && var.include_global_resource_types
+
+    dynamic "exclusion_by_resource_types" {
+      for_each = length(var.exclude_resource_types) > 0 ? [1] : []
+      content {
+        resource_types = var.exclude_resource_types
+      }
+    }
+
+    resource_types = local.include_resource_types
+
+    recording_strategy {
+      use_only = length(local.include_resource_types) > 0 ? "INCLUSION_BY_RESOURCE_TYPES" : (
+        length(var.exclude_resource_types) > 0 ? "EXCLUSION_BY_RESOURCE_TYPES" : "ALL_SUPPORTED_RESOURCE_TYPES"
+      )
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.exclude_resource_types) == 0 || contains(var.include_resource_types, "*")
+      error_message = "exclude_resource_types requires wildcarding include_resource_types."
+    }
   }
 }
 

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -1,1 +1,4 @@
-
+locals {
+  all_supported          = length(var.include_resource_types) + length(var.exclude_resource_types) == 0
+  include_resource_types = [for t in var.include_resource_types : t if t != "*"]
+}

--- a/modules/config/tests/config.tftest.hcl
+++ b/modules/config/tests/config.tftest.hcl
@@ -1,0 +1,22 @@
+run "default_include_all" {
+  command = plan
+  variables {
+    name   = "some-test"
+    bucket = "my-example-test"
+  }
+}
+
+run "test_mutually_exclusive_args" {
+  command = plan
+  variables {
+    name   = "some-test"
+    bucket = "my-example-test"
+
+    include_resource_types = ["AWS::EC2::Hohoho"]
+    exclude_resource_types = ["AWS::EC2::Instance"]
+  }
+
+  expect_failures = [
+    aws_config_configuration_recorder.this
+  ]
+}

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -19,19 +19,56 @@ variable "prefix" {
 }
 
 variable "delivery_frequency" {
-  description = "The frequency with which AWS Config recurringly delivers configuration snapshots. Valid values: One_Hour, Three_Hours, Six_Hours, Twelve_Hours, TwentyFour_Hours (https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html)."
+  description = <<-EOF
+    The frequency with which AWS Config recurringly delivers configuration
+    snapshots. Valid values: One_Hour, Three_Hours, Six_Hours, Twelve_Hours,
+    TwentyFour_Hours
+    (https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html)."
+    EOF
   type        = string
   default     = "Three_Hours"
+  nullable    = false
+
+  validation {
+    condition     = contains(["One_Hour", "Three_Hours", "Six_Hours", "Twelve_Hours", "TwentyFour_Hours"], var.delivery_frequency)
+    error_message = "unsupported delivery frequency value."
+  }
+}
+
+variable "include_resource_types" {
+  description = <<-EOF
+    Restrict configuration collection to a subset of resource types.
+  EOF
+  type        = list(string)
+  default     = ["*"]
+  nullable    = false
+
+  validation {
+    condition     = length(var.include_resource_types) > 0
+    error_message = "include_resource_types cannot be empty, otherwise module would not be needed."
+  }
+}
+
+variable "exclude_resource_types" {
+  description = <<-EOF
+    Exclude a subset of resource types from configuration collection. This
+    parameter is mutually exclusive with IncludeResourceTypes.
+  EOF
+  type        = list(string)
+  default     = []
   nullable    = false
 }
 
 variable "include_global_resource_types" {
   description = <<-EOF
-    Specifies whether AWS Config includes all supported types of global resources with the resources that it records.
+    Specifies whether AWS Config includes all supported types of global
+    resources with the resources that it records. This field only takes
+    effect if all resources are included for collection. include_resource_types
+    must be set to *, and exclude_resource_types must not be set.
   EOF
   type        = bool
   default     = true
-  nullable    = true
+  nullable    = false
 }
 
 variable "sns_topic_arn" {

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This commit provides parity configuration wise with what is provided in our AWS SAM cloudformation templates.
