### PR TITLE
fix: bump minimum terraform version to 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module "observe_collection" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/forwarder/README.md
+++ b/modules/forwarder/README.md
@@ -57,7 +57,7 @@ module "forwarder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/modules/forwarder/versions.tf
+++ b/modules/forwarder/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {


### PR DESCRIPTION
For consistency across modules, pin the minimum terraform version to 1.2. This avoids issues in our current test actions where we detect the minimum version based on the root module, rather than computing the minimum based on the module being tested.