### PR TITLE
fix(forwarder): output queue ARN

### DIFF
--- a/modules/forwarder/README.md
+++ b/modules/forwarder/README.md
@@ -114,7 +114,9 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_queue_arn"></a> [queue\_arn](#output\_queue\_arn) | SQS Queue ARN |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/modules/forwarder/outputs.tf
+++ b/modules/forwarder/outputs.tf
@@ -1,0 +1,4 @@
+output "queue_arn" {
+  description = "SQS Queue ARN"
+  value       = aws_sqs_queue.this.arn
+}

--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -98,15 +98,15 @@ resource "aws_cloudwatch_log_subscription_filter" "lambda_cloudwatch_subscriptio
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | S3 Bucket ARN to write log records to. | `string` | n/a | yes |
 | <a name="input_buffering_interval"></a> [buffering\_interval](#input\_buffering\_interval) | Buffer incoming data for the specified period of time, in seconds, before<br>delivering it to S3. | `number` | `60` | no |
 | <a name="input_buffering_size"></a> [buffering\_size](#input\_buffering\_size) | Buffer incoming data to the specified size, in MiBs, before delivering it<br>to S3. | `number` | `1` | no |
-| <a name="input_discovery_rate"></a> [discovery\_rate](#input\_discovery\_rate) | EventBridge rate expression for periodically triggering discovery. If not set, no eventbridge rules are configured. | `string` | `null` | no |
-| <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Subscription filter name. Existing filters that have this name as a prefix will be removed. | `string` | `null` | no |
+| <a name="input_discovery_rate"></a> [discovery\_rate](#input\_discovery\_rate) | EventBridge rate expression for periodically triggering discovery. If not<br>set, no eventbridge rules are configured. | `string` | `null` | no |
+| <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Subscription filter name. Existing filters that have this name as a prefix<br>will be removed. | `string` | `null` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | Subscription filter pattern. | `string` | `null` | no |
 | <a name="input_lambda_env_vars"></a> [lambda\_env\_vars](#input\_lambda\_env\_vars) | Environment variables to be passed into lambda. | `map(string)` | `null` | no |
 | <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Memory size for lambda function. | `number` | `null` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `null` | no |
-| <a name="input_log_group_name_patterns"></a> [log\_group\_name\_patterns](#input\_log\_group\_name\_patterns) | List of patterns as strings. We will only subscribe to log groups that have names matching one of the provided strings based on strings based on a case-sensitive substring search. To subscribe to all log groups, use the wildcard operator *. | `list(string)` | `null` | no |
-| <a name="input_log_group_name_prefixes"></a> [log\_group\_name\_prefixes](#input\_log\_group\_name\_prefixes) | List of prefixes as strings. The lambda function will only apply to log groups that start with a provided string. To subscribe to all log groups, use the wildcard operator *. | `list(string)` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of role. Since this name must be unique within the<br>account, it will be reused for most of the resources created by this<br>module. | `string` | n/a | yes |
+| <a name="input_log_group_name_patterns"></a> [log\_group\_name\_patterns](#input\_log\_group\_name\_patterns) | Subscribe to CloudWatch log groups matching any of the provided patterns<br>based on a case-sensitive substring search. To subscribe to all log groups<br>use the wildcard operator *. | `list(string)` | `null` | no |
+| <a name="input_log_group_name_prefixes"></a> [log\_group\_name\_prefixes](#input\_log\_group\_name\_prefixes) | Subscribe to CloudWatch log groups matching any of the provided prefixes.<br>To subscribe to all log groups use the wildcard operator *. | `list(string)` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for resources. | `string` | n/a | yes |
 | <a name="input_num_workers"></a> [num\_workers](#input\_num\_workers) | Maximum number of concurrent workers when processing log groups. | `number` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Optional prefix to write log records to. | `string` | `"observe"` | no |
 

--- a/modules/logwriter/iam.tf
+++ b/modules/logwriter/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "firehose" {
-  name_prefix        = "${var.name}-"
+  name_prefix        = local.name_prefix
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role_policy.json
 
   dynamic "inline_policy" {
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "firehose_s3writer" {
 }
 
 resource "aws_iam_role" "destination" {
-  name_prefix        = "${var.name}-"
+  name_prefix        = local.name_prefix
   assume_role_policy = data.aws_iam_policy_document.destination_assume_role_policy.json
 
   inline_policy {

--- a/modules/logwriter/main.tf
+++ b/modules/logwriter/main.tf
@@ -2,4 +2,5 @@ locals {
   enable_subscription         = anytrue([local.has_log_group_name_patterns, local.has_log_group_name_prefixes])
   has_log_group_name_patterns = var.log_group_name_patterns != null ? join(",", var.log_group_name_patterns) != "" : false
   has_log_group_name_prefixes = var.log_group_name_prefixes != null ? join(",", var.log_group_name_prefixes) != "" : false
+  name_prefix                 = "${substr(var.name, 0, 37)}-"
 }

--- a/modules/logwriter/variables.tf
+++ b/modules/logwriter/variables.tf
@@ -2,9 +2,7 @@ variable "name" {
   type        = string
   nullable    = false
   description = <<-EOF
-    Name of role. Since this name must be unique within the
-    account, it will be reused for most of the resources created by this
-    module.
+    Name for resources.
   EOF
 
   validation {
@@ -14,7 +12,9 @@ variable "name" {
 }
 
 variable "bucket_arn" {
-  description = "S3 Bucket ARN to write log records to."
+  description = <<-EOF
+    S3 Bucket ARN to write log records to.
+  EOF
   type        = string
   nullable    = false
 }
@@ -47,55 +47,78 @@ variable "buffering_size" {
 }
 
 variable "filter_name" {
-  description = "Subscription filter name. Existing filters that have this name as a prefix will be removed."
+  description = <<-EOF
+    Subscription filter name. Existing filters that have this name as a prefix
+    will be removed.
+  EOF
   type        = string
   default     = null
 }
 
 variable "filter_pattern" {
-  description = "Subscription filter pattern."
+  description = <<-EOF
+    Subscription filter pattern.
+  EOF
   type        = string
   default     = null
 }
 
 variable "log_group_name_patterns" {
-  description = "List of patterns as strings. We will only subscribe to log groups that have names matching one of the provided strings based on strings based on a case-sensitive substring search. To subscribe to all log groups, use the wildcard operator *."
+  description = <<-EOF
+    Subscribe to CloudWatch log groups matching any of the provided patterns
+    based on a case-sensitive substring search. To subscribe to all log groups
+    use the wildcard operator *.
+  EOF
   type        = list(string)
   default     = null
 }
 
 variable "log_group_name_prefixes" {
-  description = "List of prefixes as strings. The lambda function will only apply to log groups that start with a provided string. To subscribe to all log groups, use the wildcard operator *."
+  description = <<-EOF
+    Subscribe to CloudWatch log groups matching any of the provided prefixes.
+    To subscribe to all log groups use the wildcard operator *.
+  EOF
   type        = list(string)
   default     = null
 }
 
 variable "num_workers" {
-  description = "Maximum number of concurrent workers when processing log groups."
+  description = <<-EOF
+    Maximum number of concurrent workers when processing log groups.
+  EOF
   type        = number
   default     = null
 }
 
 variable "discovery_rate" {
-  description = "EventBridge rate expression for periodically triggering discovery. If not set, no eventbridge rules are configured."
+  description = <<-EOF
+    EventBridge rate expression for periodically triggering discovery. If not
+    set, no eventbridge rules are configured.
+  EOF
   type        = string
   default     = null
 }
 
 variable "lambda_memory_size" {
-  description = "Memory size for lambda function."
+  description = <<-EOF
+    Memory size for lambda function.
+  EOF
   type        = number
   default     = null
 }
 
 variable "lambda_timeout" {
-  description = "Timeout in seconds for lambda function."
+  description = <<-EOF
+    Timeout in seconds for lambda function.
+  EOF
   type        = number
   default     = null
 }
 
 variable "lambda_env_vars" {
-  description = "Environment variables to be passed into lambda."
+  description = <<-EOF
+    Environment variables to be passed into lambda.
+  EOF
   type        = map(string)
   default     = null
 }

--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -48,7 +48,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_destination_iam_arn"></a> [destination\_iam\_arn](#input\_destination\_iam\_arn) | ARN for destination iam policy | `string` | n/a | yes |
-| <a name="input_discovery_rate"></a> [discovery\_rate](#input\_discovery\_rate) | EventBridge rate expression for periodically triggering discovery. If not set, no eventbridge rules are configured. | `string` | n/a | yes |
+| <a name="input_discovery_rate"></a> [discovery\_rate](#input\_discovery\_rate) | EventBridge scheduler rate expression for periodically triggering discovery. If not set, no scheduler is configured. | `string` | `""` | no |
 | <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Subscription filter name. Existing filters that have this name as a prefix will be removed. | `string` | `"observe-logs-subscription"` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | Subscription filter pattern. | `string` | `""` | no |
 | <a name="input_firehose_arn"></a> [firehose\_arn](#input\_firehose\_arn) | ARN for kinesis firehose | `string` | n/a | yes |
@@ -57,7 +57,7 @@ No modules.
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `20` | no |
 | <a name="input_log_group_name_patterns"></a> [log\_group\_name\_patterns](#input\_log\_group\_name\_patterns) | List of patterns as strings. We will only subscribe to log groups that have names matching one of the provided strings based on strings based on a case-sensitive substring search. To subscribe to all log groups, use the wildcard operator *. | `list(string)` | `[]` | no |
 | <a name="input_log_group_name_prefixes"></a> [log\_group\_name\_prefixes](#input\_log\_group\_name\_prefixes) | List of prefixes as strings. The lambda function will only apply to log groups that start with a provided string. To subscribe to all log groups, use the wildcard operator *. | `list(string)` | `[]` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of role. Since this name must be unique within the<br>account, it will be reused for most of the resources created by this<br>module. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for resources. | `string` | n/a | yes |
 | <a name="input_num_workers"></a> [num\_workers](#input\_num\_workers) | Maximum number of concurrent workers when processing log groups. | `number` | `1` | no |
 
 ## Outputs

--- a/modules/subscriber/iam.tf
+++ b/modules/subscriber/iam.tf
@@ -1,6 +1,6 @@
 
 resource "aws_iam_role" "subscriber" {
-  name_prefix        = "${var.name}-"
+  name_prefix        = local.name_prefix
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 
   dynamic "inline_policy" {
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "subscription_policy" {
 }
 
 resource "aws_iam_role" "scheduler" {
-  name_prefix        = "${var.name}-"
+  name_prefix        = local.name_prefix
   assume_role_policy = data.aws_iam_policy_document.scheduler_assume_role_policy.json
 
   inline_policy {

--- a/modules/subscriber/main.tf
+++ b/modules/subscriber/main.tf
@@ -1,5 +1,6 @@
 locals {
   has_discovery_rate = var.discovery_rate != ""
+  name_prefix        = "${substr(var.name, 0, 37)}-"
 
   s3_uri        = one([for item in csvdecode(file("${path.module}/uris.csv")) : item["code_uri"] if item["region"] == data.aws_region.current.name])
   parsed_s3_uri = regex("s3://(?P<bucket>[^/]+)/(?P<key>.+)", local.s3_uri)

--- a/modules/subscriber/scheduler.tf
+++ b/modules/subscriber/scheduler.tf
@@ -1,6 +1,6 @@
 resource "aws_scheduler_schedule" "discovery_schedule" {
   count       = local.has_discovery_rate ? 1 : 0
-  name        = var.name
+  name_prefix = local.name_prefix
   description = "Trigger log group discovery"
   state       = "ENABLED"
   flexible_time_window {

--- a/modules/subscriber/variables.tf
+++ b/modules/subscriber/variables.tf
@@ -2,9 +2,7 @@ variable "name" {
   type        = string
   nullable    = false
   description = <<-EOF
-    Name of role. Since this name must be unique within the
-    account, it will be reused for most of the resources created by this
-    module.
+    Name for resources.
   EOF
 
   validation {
@@ -68,11 +66,14 @@ variable "log_group_name_prefixes" {
 }
 
 variable "discovery_rate" {
-  description = "EventBridge rate expression for periodically triggering discovery. If not set, no eventbridge rules are configured."
+  description = "EventBridge scheduler rate expression for periodically triggering discovery. If not set, no scheduler is configured."
   type        = string
+  default     = ""
+  nullable    = false
+
   validation {
-    condition     = can(regex("^\\d+ (minutes|hours|days)$", var.discovery_rate))
-    error_message = "Discovery_rate must be a valid rate expression of a positive number followed by (minutes|hours|days) ex. 10 minutes."
+    condition     = can(regex("^(\\d+ (minutes|hours|days))?$", var.discovery_rate))
+    error_message = "Value is not a valid EventBridge scheduler rate expression (https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#rate-based)."
   }
 }
 


### PR DESCRIPTION
This is needed in order for other modules to trigger the forwarder by queuing tasks for the lambda to process.