### PR TITLE
feat(testing): encrypt S3 bucket using KMS

### DIFF
--- a/modules/logwriter/tests/logwriter.tftest.hcl
+++ b/modules/logwriter/tests/logwriter.tftest.hcl
@@ -17,7 +17,7 @@ run "create_bucket" {
 run "install_logwriter" {
   variables {
     name                    = run.setup.short
-    bucket_arn              = run.create_bucket.bucket_arn
+    bucket_arn              = run.create_bucket.arn
     discovery_rate          = "10 minutes"
     filter_name             = "${run.setup.id}-filter"
     log_group_name_patterns = ["${run.setup.short}"]

--- a/modules/metricstream/tests/metricstream.tftest.hcl
+++ b/modules/metricstream/tests/metricstream.tftest.hcl
@@ -17,7 +17,7 @@ run "create_bucket" {
 run "install" {
   variables {
     name       = run.setup.id
-    bucket_arn = run.create_bucket.bucket_arn
+    bucket_arn = run.create_bucket.arn
     include_filters = [
       {
         namespace    = "AWS/RDS"

--- a/modules/testing/s3_bucket/kms.tf
+++ b/modules/testing/s3_bucket/kms.tf
@@ -1,0 +1,11 @@
+resource "aws_kms_key" "this" {
+  count               = var.kms_key_policy_json != "" ? 1 : 0
+  enable_key_rotation = true
+  policy              = var.kms_key_policy_json
+}
+
+resource "aws_kms_alias" "this" {
+  count         = length(aws_kms_key.this)
+  name          = "alias/${var.setup.short}"
+  target_key_id = aws_kms_key.this[0].key_id
+}

--- a/modules/testing/s3_bucket/main.tf
+++ b/modules/testing/s3_bucket/main.tf
@@ -8,3 +8,15 @@ resource "aws_s3_access_point" "this" {
   bucket = aws_s3_bucket.this.id
   name   = var.setup.short
 }
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  count  = length(aws_kms_key.this)
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.this[0].arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}

--- a/modules/testing/s3_bucket/outputs.tf
+++ b/modules/testing/s3_bucket/outputs.tf
@@ -1,6 +1,11 @@
-output "bucket_arn" {
+output "arn" {
   description = "S3 Bucket arn"
   value       = aws_s3_bucket.this.arn
+}
+
+output "id" {
+  description = "S3 Bucket name"
+  value       = aws_s3_bucket.this.id
 }
 
 output "access_point" {
@@ -8,4 +13,7 @@ output "access_point" {
   value       = one(aws_s3_access_point.this)
 }
 
-
+output "kms_key" {
+  description = "KMS key used to encrypt bucket"
+  value       = one(aws_kms_key.this)
+}

--- a/modules/testing/s3_bucket/variables.tf
+++ b/modules/testing/s3_bucket/variables.tf
@@ -11,3 +11,10 @@ variable "enable_access_point" {
   default     = true
   nullable    = false
 }
+
+variable "kms_key_policy_json" {
+  description = "JSON encoded KMS key policy. If set, the S3 bucket will be encrypted using a KMS key."
+  type        = string
+  default     = ""
+  nullable    = false
+}


### PR DESCRIPTION
Add the ability to encrypt S3 bucket using a KMS key to our testing setup module. This will allow us to verify that we can grant the forwarder lambda permissions to decrypt data given a KMS key.