### PR TITLE
feat: add debug_endpoint param for OTEL debugging

### DIFF
--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -92,6 +92,7 @@ module "logwriter" {
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | S3 Bucket ARN to write log records to. | `string` | n/a | yes |
 | <a name="input_buffering_interval"></a> [buffering\_interval](#input\_buffering\_interval) | Buffer incoming data for the specified period of time, in seconds, before<br>delivering it to S3. | `number` | `60` | no |
 | <a name="input_buffering_size"></a> [buffering\_size](#input\_buffering\_size) | Buffer incoming data to the specified size, in MiBs, before delivering it<br>to S3. | `number` | `1` | no |
+| <a name="input_debug_endpoint"></a> [debug\_endpoint](#input\_debug\_endpoint) | Endpoint to send debugging telemetry to. Sets the OTEL\_EXPORTER\_OTL\_ENDPOINT environment variable for the lambda function. | `string` | `null` | no |
 | <a name="input_discovery_rate"></a> [discovery\_rate](#input\_discovery\_rate) | EventBridge rate expression for periodically triggering discovery. If not<br>set, no eventbridge rules are configured. | `string` | `null` | no |
 | <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Subscription filter name. Existing filters that have this name as a prefix<br>will be removed. | `string` | `null` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | Subscription filter pattern. | `string` | `null` | no |

--- a/modules/logwriter/subscriber.tf
+++ b/modules/logwriter/subscriber.tf
@@ -14,4 +14,5 @@ module "subscriber" {
   lambda_env_vars         = var.lambda_env_vars
   lambda_memory_size      = var.lambda_memory_size
   lambda_timeout          = var.lambda_timeout
+  debug_endpoint          = var.debug_endpoint
 }

--- a/modules/logwriter/tests/logwriter.tftest.hcl
+++ b/modules/logwriter/tests/logwriter.tftest.hcl
@@ -21,5 +21,6 @@ run "install_logwriter" {
     discovery_rate          = "10 minutes"
     filter_name             = "${run.setup.id}-filter"
     log_group_name_patterns = ["${run.setup.short}"]
+    debug_endpoint          = "http://localhost:8080"
   }
 }

--- a/modules/logwriter/variables.tf
+++ b/modules/logwriter/variables.tf
@@ -122,3 +122,9 @@ variable "lambda_env_vars" {
   type        = map(string)
   default     = null
 }
+
+variable "debug_endpoint" {
+  description = "Endpoint to send debugging telemetry to. Sets the OTEL_EXPORTER_OTL_ENDPOINT environment variable for the lambda function."
+  type        = string
+  default     = null
+}

--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -47,6 +47,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_debug_endpoint"></a> [debug\_endpoint](#input\_debug\_endpoint) | Endpoint to send debugging telemetry to. Sets the OTEL\_EXPORTER\_OTL\_ENDPOINT environment variable for the lambda function. | `string` | `""` | no |
 | <a name="input_destination_iam_arn"></a> [destination\_iam\_arn](#input\_destination\_iam\_arn) | ARN for destination iam policy | `string` | n/a | yes |
 | <a name="input_discovery_rate"></a> [discovery\_rate](#input\_discovery\_rate) | EventBridge scheduler rate expression for periodically triggering discovery. If not set, no scheduler is configured. | `string` | `""` | no |
 | <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Subscription filter name. Existing filters that have this name as a prefix will be removed. | `string` | `"observe-logs-subscription"` | no |

--- a/modules/subscriber/lambda.tf
+++ b/modules/subscriber/lambda.tf
@@ -16,15 +16,16 @@ resource "aws_lambda_function" "subscriber" {
 
   environment {
     variables = merge({
-      FILTER_NAME             = var.filter_name
-      FILTER_PATTERN          = var.filter_pattern
-      DESTINATION_ARN         = var.firehose_arn
-      LOG_GROUP_NAME_PREFIXES = join(",", var.log_group_name_prefixes)
-      LOG_GROUP_NAME_PATTERNS = join(",", var.log_group_name_patterns)
-      ROLE_ARN                = var.destination_iam_arn
-      QUEUE_URL               = aws_sqs_queue.queue.id
-      VERBOSITY               = 9
-      NUM_WORKERS             = var.num_workers
+      FILTER_NAME                 = var.filter_name
+      FILTER_PATTERN              = var.filter_pattern
+      DESTINATION_ARN             = var.firehose_arn
+      LOG_GROUP_NAME_PREFIXES     = join(",", var.log_group_name_prefixes)
+      LOG_GROUP_NAME_PATTERNS     = join(",", var.log_group_name_patterns)
+      ROLE_ARN                    = var.destination_iam_arn
+      QUEUE_URL                   = aws_sqs_queue.queue.id
+      VERBOSITY                   = 9
+      NUM_WORKERS                 = var.num_workers
+      OTEL_EXPORTER_OTLP_ENDPOINT = var.debug_endpoint
     }, var.lambda_env_vars)
   }
 }

--- a/modules/subscriber/variables.tf
+++ b/modules/subscriber/variables.tf
@@ -104,3 +104,10 @@ variable "lambda_env_vars" {
   nullable    = false
   default     = {}
 }
+
+variable "debug_endpoint" {
+  description = "Endpoint to send debugging telemetry to. Sets the OTEL_EXPORTER_OTL_ENDPOINT environment variable for the lambda function."
+  type        = string
+  nullable    = false
+  default     = ""
+}


### PR DESCRIPTION
## What does this PR do?

Adds new optional parameter `debug_endpoint` that when set starts emitting debugging telemetry data.

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - let us know what you've done for testing so far. It helps the 
reviewer consider what more can be done to build confidence in the safety 
of the change. 
