### PR TITLE
docs: add KMS forwarding example

### DIFF
--- a/examples/forwarder-kms/README.md
+++ b/examples/forwarder-kms/README.md
@@ -1,6 +1,58 @@
 # Forwarding KMS encrypted buckets
 
-This module exemplifies how to forward objects from a KMS encrypted bucket. The
+This module demonstrates how to forward objects from a KMS encrypted bucket. The
 `forwarder` module must be configured with a list of `source_kms_key_arns`, and
 the KMS key must have a policy that grants the lambda function permission to
 decrypt objects.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_observe"></a> [observe](#requirement\_observe) | ~> 0.14 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_observe"></a> [observe](#provider\_observe) | ~> 0.14 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_forwarder"></a> [forwarder](#module\_forwarder) | ../..//modules/forwarder | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_key.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.destination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_notification.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| observe_datastream.this | resource |
+| observe_filedrop.this | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.kms_default_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| observe_workspace.default | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_datastream"></a> [datastream](#output\_datastream) | Observe Datastream containing data copied from source bucket. |
+| <a name="output_source_bucket"></a> [source\_bucket](#output\_source\_bucket) | Source bucket name to write objects to. This bucket is encrypted using KMS. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/forwarder-kms/outputs.tf
+++ b/examples/forwarder-kms/outputs.tf
@@ -1,0 +1,9 @@
+output "source_bucket" {
+  description = "Source bucket name to write objects to. This bucket is encrypted using KMS."
+  value       = aws_s3_bucket.source
+}
+
+output "datastream" {
+  description = "Observe Datastream containing data copied from source bucket."
+  value       = observe_datastream.this
+}

--- a/examples/forwarder-kms/tests/example.tftest.hcl
+++ b/examples/forwarder-kms/tests/example.tftest.hcl
@@ -1,0 +1,6 @@
+mock_provider "observe" {
+  source = "../../modules/testing/observe_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/forwarder-kms/versions.tf
+++ b/examples/forwarder-kms/versions.tf
@@ -16,6 +16,5 @@ terraform {
       source  = "terraform.observeinc.com/observeinc/observe"
       version = "~> 0.14"
     }
-
   }
 }

--- a/modules/testing/observe_mock/README.md
+++ b/modules/testing/observe_mock/README.md
@@ -1,0 +1,3 @@
+# Observe mock
+
+This module provides a terraform test mock for the Observe provider.

--- a/modules/testing/observe_mock/observe.tfmock.hcl
+++ b/modules/testing/observe_mock/observe.tfmock.hcl
@@ -1,0 +1,31 @@
+mock_data "observe_workspace" {
+  defaults = {
+    oid = "o:::workspace:41067315"
+  }
+}
+
+mock_resource "observe_datastream" {
+  defaults = {
+    oid  = "o:::datastream:41567890"
+  }
+}
+
+mock_resource "observe_filedrop" {
+  defaults = {
+    id         = "41000000"
+    name       = "filedrop-ds1pUUtmcrPETeLAwJeR"
+    oid        = "o:::filedrop:41567892"
+    status     = "running"
+    endpoint = [
+      {
+        s3 = [
+          {
+            arn    = "arn:aws:s3:us-west-2:123456789012:accesspoint/000000000000"
+            bucket = "000000000000-s1n88tucur4944c6p3ymbu6hr758gusw2a-s3alias"
+            prefix = "ds1pUUtmcrPETeLAwJeR/"
+          },
+        ]
+      },
+    ]
+  }
+}


### PR DESCRIPTION
Add an example module that demonstrates reading files from KMS encrypted bucket. We introduce a mock provider in order to avoid needing Observe credentials to run tests.
