### PR TITLE
fix(forwarder): set name_prefix for eventbridge rule

### DIFF
--- a/modules/forwarder/eventbridge.tf
+++ b/modules/forwarder/eventbridge.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "this" {
-  name           = "${substr(var.name, 0, 37)}-"
+  name_prefix    = "${substr(var.name, 0, 37)}-"
   description    = "Trigger copy for object created events"
   event_bus_name = "default"
 


### PR DESCRIPTION
We don't need this rule to have a known name, and we were providing a prefix.