### PR TITLE
feat: allow subscribing S3 bucket notifications to eventbridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ module "observe_collection" {
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.2.0 |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.2.0 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.2.0 |
-| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.4.0 |
-| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.4.0 |
-| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.4.0 |
+| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.5.0 |
+| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.5.0 |
+| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.5.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 
 ## Resources
@@ -132,6 +132,7 @@ module "observe_collection" {
 | <a name="input_cloudwatch_metrics_exclude_filters"></a> [cloudwatch\_metrics\_exclude\_filters](#input\_cloudwatch\_metrics\_exclude\_filters) | Namespaces to exclude. Mutually exclusive with cloudwatch\_metrics\_include\_filters.<br><br>To disable Cloudwatch Metrics Stream entirely, use ["*"]. | `set(string)` | `[]` | no |
 | <a name="input_cloudwatch_metrics_include_filters"></a> [cloudwatch\_metrics\_include\_filters](#input\_cloudwatch\_metrics\_include\_filters) | Namespaces to include. Mutually exclusive with cloudwatch\_metrics\_exclude\_filters. | `set(string)` | `[]` | no |
 | <a name="input_dead_letter_queue_destination"></a> [dead\_letter\_queue\_destination](#input\_dead\_letter\_queue\_destination) | Send failed events/function executions to a dead letter queue arn sns or sqs | `string` | `null` | no |
+| <a name="input_enable_s3_bucket_eventbridge"></a> [enable\_s3\_bucket\_eventbridge](#input\_enable\_s3\_bucket\_eventbridge) | Enable sending bucket notifications to EventBridge | `bool` | `false` | no |
 | <a name="input_eventbridge_rules"></a> [eventbridge\_rules](#input\_eventbridge\_rules) | Eventbridge events matching these rules will be forwarded to Observe. Map<br>keys are only used to provide stable resource addresses.<br><br>If null, a default set of rules will be used. | <pre>map(object({<br>    description   = string<br>    event_pattern = string<br>  }))</pre> | `null` | no |
 | <a name="input_invoke_snapshot_on_start_enabled"></a> [invoke\_snapshot\_on\_start\_enabled](#input\_invoke\_snapshot\_on\_start\_enabled) | Toggle invocation of snapshot from Cloudformation. This can be useful for debug purposes if the lambda fails to complete successfully. | `bool` | `false` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key ARN to use to encrypt the logs delivered by CloudTrail. | `string` | `""` | no |

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,6 +1,6 @@
 module "observe_lambda" {
   source  = "observeinc/lambda/aws"
-  version = "3.4.0"
+  version = "3.5.0"
 
   name             = var.name
   observe_domain   = var.observe_domain
@@ -22,7 +22,7 @@ module "observe_lambda" {
 
 module "observe_lambda_snapshot" {
   source  = "observeinc/lambda/aws//modules/snapshot"
-  version = "3.4.0"
+  version = "3.5.0"
 
   lambda                           = module.observe_lambda
   eventbridge_name_prefix          = local.name_prefix

--- a/s3.tf
+++ b/s3.tf
@@ -183,10 +183,11 @@ data "aws_iam_policy_document" "bucket" {
 
 module "observe_lambda_s3_bucket_subscription" {
   source  = "observeinc/lambda/aws//modules/s3_bucket_subscription"
-  version = "3.4.0"
+  version = "3.5.0"
 
-  lambda          = module.observe_lambda.lambda_function
-  bucket_arns     = concat([local.s3_bucket.arn], var.subscribed_s3_bucket_arns)
-  iam_name_prefix = local.name_prefix
-  filter_prefix   = local.s3_exported_prefix
+  lambda             = module.observe_lambda.lambda_function
+  bucket_arns        = concat([local.s3_bucket.arn], var.subscribed_s3_bucket_arns)
+  iam_name_prefix    = local.name_prefix
+  filter_prefix      = local.s3_exported_prefix
+  enable_eventbridge = var.enable_s3_bucket_eventbridge
 }

--- a/variables.tf
+++ b/variables.tf
@@ -303,3 +303,10 @@ variable "invoke_snapshot_on_start_enabled" {
   type        = bool
   default     = false
 }
+
+variable "enable_s3_bucket_eventbridge" {
+  description = "Enable sending bucket notifications to EventBridge"
+  type        = bool
+  nullable    = false
+  default     = false
+}


### PR DESCRIPTION
This can be useful for the case where we want to subscribe our collection bucket to multiple downstream consumers.