### PR TITLE
fix: CS-425 update default aws snapshot lambda to 2gb and timeout 120s

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ module "observe_collection" {
 | <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.2.0 |
 | <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.2.0 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.2.0 |
-| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.5.0 |
-| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.5.0 |
-| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.5.0 |
+| <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.5.1 |
+| <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.5.1 |
+| <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.5.1 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 
 ## Resources

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,6 +1,6 @@
 module "observe_lambda" {
   source  = "observeinc/lambda/aws"
-  version = "3.5.0"
+  version = "3.5.1"
 
   name             = var.name
   observe_domain   = var.observe_domain
@@ -22,7 +22,7 @@ module "observe_lambda" {
 
 module "observe_lambda_snapshot" {
   source  = "observeinc/lambda/aws//modules/snapshot"
-  version = "3.5.0"
+  version = "3.5.1"
 
   lambda                           = module.observe_lambda
   eventbridge_name_prefix          = local.name_prefix

--- a/s3.tf
+++ b/s3.tf
@@ -183,7 +183,7 @@ data "aws_iam_policy_document" "bucket" {
 
 module "observe_lambda_s3_bucket_subscription" {
   source  = "observeinc/lambda/aws//modules/s3_bucket_subscription"
-  version = "3.5.0"
+  version = "3.5.1"
 
   lambda             = module.observe_lambda.lambda_function
   bucket_arns        = concat([local.s3_bucket.arn], var.subscribed_s3_bucket_arns)


### PR DESCRIPTION
CS-425 update default aws snapshot lambda to 2gb and timeout to 120 seconds

## What does this PR do?

Required - tell us about the great change you're submitting! It helps us know
what we need to review and how to collaborate on making it better.

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - let us know what you've done for testing so far. It helps the 
reviewer consider what more can be done to build confidence in the safety 
of the change. 
