### PR TITLE
fix(configsubscription): match targets, relax permissions

### DIFF
--- a/modules/configsubscription/change.tf
+++ b/modules/configsubscription/change.tf
@@ -13,6 +13,6 @@ resource "aws_cloudwatch_event_rule" "change" {
 }
 
 resource "aws_cloudwatch_event_target" "change" {
-  rule = aws_cloudwatch_event_rule.delivery.name
+  rule = aws_cloudwatch_event_rule.change.name
   arn  = var.target_arn
 }

--- a/modules/configsubscription/oversized.tf
+++ b/modules/configsubscription/oversized.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_event_rule" "oversized" {
 }
 
 resource "aws_cloudwatch_event_target" "oversized" {
-  rule = aws_cloudwatch_event_rule.delivery.name
+  rule = aws_cloudwatch_event_rule.oversized.name
   arn  = var.target_arn
 
   input_transformer {

--- a/modules/forwarder/queue.tf
+++ b/modules/forwarder/queue.tf
@@ -53,11 +53,6 @@ resource "aws_sqs_queue" "this" {
         Principal = {
           "Service" : "events.amazonaws.com"
         },
-        Condition = {
-          ArnEquals = {
-            "aws:SourceArn" : aws_cloudwatch_event_rule.this.arn
-          }
-        }
       },
     ]
   })


### PR DESCRIPTION
Our targets were all referencing the same rule, and were additionally not able to write to SQS due to stringent permissions on the forwarder queue. This commit fixes the target references, and additionally relaxes forwarder policy to match what we do in our CloudFormation template.