### PR TITLE
fix(forwarder): adjust defaults based on URI

### DIFF
--- a/modules/forwarder/README.md
+++ b/modules/forwarder/README.md
@@ -103,9 +103,9 @@ No modules.
 | <a name="input_debug_endpoint"></a> [debug\_endpoint](#input\_debug\_endpoint) | Endpoint to send debugging telemetry to. Sets the OTEL\_EXPORTER\_OTLP\_ENDPOINT environment variable for the lambda function. | `string` | `""` | no |
 | <a name="input_destination"></a> [destination](#input\_destination) | Destination filedrop | <pre>object({<br>    arn    = optional(string, "")<br>    bucket = optional(string, "")<br>    prefix = optional(string, "")<br>    # exclusively for backward compatible HTTP endpoint<br>    uri = optional(string, "")<br>  })</pre> | n/a | yes |
 | <a name="input_lambda_env_vars"></a> [lambda\_env\_vars](#input\_lambda\_env\_vars) | Environment variables to be passed into lambda. | `map(string)` | `{}` | no |
-| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Memory size for lambda function. | `number` | `128` | no |
-| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `300` | no |
-| <a name="input_max_file_size"></a> [max\_file\_size](#input\_max\_file\_size) | Max file size for objects to process (in bytes), default is 1GB | `number` | `1073741824` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Memory size for lambda function. | `number` | `null` | no |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `null` | no |
+| <a name="input_max_file_size"></a> [max\_file\_size](#input\_max\_file\_size) | Max file size for objects to process (in bytes), default is 1GB | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of role. Since this name must be unique within the<br>account, it will be reused for most of the resources created by this<br>module. | `string` | n/a | yes |
 | <a name="input_queue_batch_size"></a> [queue\_batch\_size](#input\_queue\_batch\_size) | Max number of items to process in single lambda execution | `number` | `10` | no |
 | <a name="input_queue_delay_seconds"></a> [queue\_delay\_seconds](#input\_queue\_delay\_seconds) | The time in seconds that the delivery of all messages in the queue will be<br>delayed. An integer from 0 to 900 (15 minutes). | `number` | `0` | no |

--- a/modules/forwarder/lambda.tf
+++ b/modules/forwarder/lambda.tf
@@ -6,13 +6,13 @@ resource "aws_lambda_function" "this" {
   architectures = ["arm64"]
   handler       = "bootstrap"
   runtime       = "provided.al2"
-  memory_size   = var.lambda_memory_size
-  timeout       = var.lambda_timeout
+  memory_size   = var.lambda_memory_size != null ? var.lambda_memory_size : local.default_limits.memory_size
+  timeout       = var.lambda_timeout != null ? var.lambda_timeout : local.default_limits.timeout
 
   environment {
     variables = merge({
       DESTINATION_URI             = local.destination_uri
-      MAX_FILE_SIZE               = var.max_file_size
+      MAX_FILE_SIZE               = var.max_file_size != null ? var.max_file_size : local.default_limits.max_file_size
       CONTENT_TYPE_OVERRIDES      = join(",", [for o in var.content_type_overrides : "${o["pattern"]}=${o["content_type"]}"])
       SOURCE_BUCKET_NAMES         = join(",", var.source_bucket_names)
       OTEL_EXPORTER_OTLP_ENDPOINT = var.debug_endpoint

--- a/modules/forwarder/main.tf
+++ b/modules/forwarder/main.tf
@@ -2,6 +2,16 @@ locals {
   s3_uri          = one([for item in csvdecode(file("${path.module}/uris.csv")) : item["code_uri"] if item["region"] == data.aws_region.current.name])
   parsed_s3_uri   = regex("s3://(?P<bucket>[^/]+)/(?P<key>.+)", local.s3_uri)
   destination_uri = var.destination.uri != "" ? var.destination.uri : "s3://${var.destination.bucket}/${var.destination.prefix}"
+
+  default_limits = startswith(local.destination_uri, "s3") ? {
+    memory_size   = 128
+    timeout       = 300
+    max_file_size = 1024 * 1024 * 1024
+    } : {
+    memory_size   = 256
+    timeout       = 300
+    max_file_size = 100 * 1024 * 1024
+  }
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/forwarder/queue.tf
+++ b/modules/forwarder/queue.tf
@@ -8,7 +8,7 @@ locals {
 resource "aws_sqs_queue" "this" {
   name = var.name
   # tie this to lambda execution time since both are tightly coupled
-  visibility_timeout_seconds = var.lambda_timeout
+  visibility_timeout_seconds = var.lambda_timeout != null ? var.lambda_timeout : local.default_limits.timeout
   delay_seconds              = var.queue_delay_seconds
   message_retention_seconds  = var.queue_message_retention_seconds
 

--- a/modules/forwarder/variables.tf
+++ b/modules/forwarder/variables.tf
@@ -79,8 +79,7 @@ variable "max_file_size" {
     Max file size for objects to process (in bytes), default is 1GB
   EOF
   type        = number
-  nullable    = false
-  default     = 1073741824
+  default     = null
 }
 
 variable "content_type_overrides" {
@@ -107,15 +106,13 @@ variable "content_type_overrides" {
 variable "lambda_memory_size" {
   description = "Memory size for lambda function."
   type        = number
-  nullable    = false
-  default     = 128
+  default     = null
 }
 
 variable "lambda_timeout" {
   description = "Timeout in seconds for lambda function."
   type        = number
-  nullable    = false
-  default     = 300
+  default     = null
 }
 
 variable "lambda_env_vars" {


### PR DESCRIPTION
Memory usage will vary according to whether we are using filedrop or sending to HTTP. When sending to HTTP, memory and CPU usage will scale according to the size of input, whereas in Filedrop the object copy is essentially scale invariant. We should adjust our defaults accordingly rather than setting them in variables.