### PR TITLE
fix(stack): add outputs

### DIFF
--- a/modules/forwarder/README.md
+++ b/modules/forwarder/README.md
@@ -122,7 +122,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_queue_arn"></a> [queue\_arn](#output\_queue\_arn) | SQS Queue ARN |
+| <a name="output_queue_arn"></a> [queue\_arn](#output\_queue\_arn) | SQS Queue ARN. Events sent to this queue are delivered to the forwarder Lambda. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/modules/forwarder/outputs.tf
+++ b/modules/forwarder/outputs.tf
@@ -1,4 +1,4 @@
 output "queue_arn" {
-  description = "SQS Queue ARN"
+  description = "SQS Queue ARN. Events sent to this queue are delivered to the forwarder Lambda."
   value       = aws_sqs_queue.this.arn
 }

--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_log_subscription_filter" "example" {
   name            = "observe-logs-subscription"
   log_group_name  = "my-example-log-group"
   destination_arn = module.logwriter.firehose_arn
-  role_arn        = module.logwriter.destination_iam_policy
+  role_arn        = module.logwriter.destination_role_arn
 }
 ```
 
@@ -113,7 +113,7 @@ module "logwriter" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_destination_iam_policy"></a> [destination\_iam\_policy](#output\_destination\_iam\_policy) | Firehose destination iam policy |
+| <a name="output_destination_role_arn"></a> [destination\_role\_arn](#output\_destination\_role\_arn) | Role for CloudWatch Logs to assume when writing to Firehose |
 | <a name="output_firehose"></a> [firehose](#output\_firehose) | Kinesis Firehose Delivery Stream ARN |
 | <a name="output_subscriber"></a> [subscriber](#output\_subscriber) | Subscriber module |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/logwriter/outputs.tf
+++ b/modules/logwriter/outputs.tf
@@ -8,7 +8,7 @@ output "firehose" {
   value       = aws_kinesis_firehose_delivery_stream.delivery_stream.arn
 }
 
-output "destination_iam_policy" {
-  description = "Firehose destination iam policy"
+output "destination_role_arn" {
+  description = "Role for CloudWatch Logs to assume when writing to Firehose"
   value       = aws_iam_role.destination.arn
 }

--- a/modules/stack/README.md
+++ b/modules/stack/README.md
@@ -110,5 +110,13 @@ module "collection_stack" {
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | S3 bucket subscribed to forwarder |
+| <a name="output_config"></a> [config](#output\_config) | Config module |
+| <a name="output_configsubscription"></a> [configsubscription](#output\_configsubscription) | ConfigSubscription module |
+| <a name="output_forwarder"></a> [forwarder](#output\_forwarder) | Forwarder module |
+| <a name="output_logwriter"></a> [logwriter](#output\_logwriter) | LogWriter module |
+| <a name="output_metricstream"></a> [metricstream](#output\_metricstream) | MetricStream module |
+| <a name="output_topic"></a> [topic](#output\_topic) | SNS topic subscribed to forwarder |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/stack/outputs.tf
+++ b/modules/stack/outputs.tf
@@ -1,0 +1,34 @@
+output "bucket" {
+  description = "S3 bucket subscribed to forwarder"
+  value       = aws_s3_bucket.this
+}
+
+output "config" {
+  description = "Config module"
+  value       = one(module.config)
+}
+
+output "configsubscription" {
+  description = "ConfigSubscription module"
+  value       = one(module.configsubscription)
+}
+
+output "forwarder" {
+  description = "Forwarder module"
+  value       = module.forwarder
+}
+
+output "logwriter" {
+  description = "LogWriter module"
+  value       = one(module.logwriter)
+}
+
+output "metricstream" {
+  description = "MetricStream module"
+  value       = one(module.metricstream)
+}
+
+output "topic" {
+  description = "SNS topic subscribed to forwarder"
+  value       = aws_sns_topic.this
+}


### PR DESCRIPTION
Our `stack` module was not surfacing any of its constituent elements. While reviewing outputs, I made minor adjustments to forwarder and logwriter outputs in order to make documentation clearer.