### PR TITLE
fix(forwarder): relax IAM role naming

### DIFF
--- a/modules/forwarder/eventbridge.tf
+++ b/modules/forwarder/eventbridge.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "this" {
-  name_prefix    = "${substr(var.name, 0, 37)}-"
+  name_prefix    = local.name_prefix
   description    = "Trigger copy for object created events"
   event_bus_name = "default"
 

--- a/modules/forwarder/iam.tf
+++ b/modules/forwarder/iam.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "this" {
-  name               = var.name
+  name               = var.destination.arn != "" ? var.name : null
+  name_prefix        = var.destination.arn != "" ? null : local.name_prefix
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
 
   dynamic "inline_policy" {

--- a/modules/forwarder/main.tf
+++ b/modules/forwarder/main.tf
@@ -2,6 +2,7 @@ locals {
   s3_uri          = one([for item in csvdecode(file("${path.module}/uris.csv")) : item["code_uri"] if item["region"] == data.aws_region.current.name])
   parsed_s3_uri   = regex("s3://(?P<bucket>[^/]+)/(?P<key>.+)", local.s3_uri)
   destination_uri = var.destination.uri != "" ? var.destination.uri : "s3://${var.destination.bucket}/${var.destination.prefix}"
+  name_prefix     = "${substr(var.name, 0, 37)}-"
 
   default_limits = startswith(local.destination_uri, "s3") ? {
     memory_size   = 128


### PR DESCRIPTION
The IAM role of the forwarder only needs to be known when forwarding data to Filedrop. For cases where we are not pointing at an S3 data access point, we can fallback to provisioning a role with `name_prefix` rather than `name`. Doing so avoids the possibility of name clashes when installing a forwarder in different regions.