### PR TITLE
fix(forwarder): strip leading whitespace in eventbridge rule

### DIFF
--- a/modules/forwarder/eventbridge.tf
+++ b/modules/forwarder/eventbridge.tf
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_event_target" "this" {
       objectKey  = "$.detail.object.key"
       objectSize = "$.detail.object.size"
     }
-    input_template = <<EOF
+    input_template = <<-EOF
       {"copy": [{"uri": "s3://<bucketName>/<objectKey>", "size": <objectSize>}]}
     EOF
   }


### PR DESCRIPTION
This is purely cosmetic, but currently the SQS message surfaces leading whitespace:

```
  "body": "      {\"copy\": [{\"uri\": \"s3://observe-collection-us-west-2-yk6du6wk/S3ServerLogs/2024-05-30-22-20-38-55B93A2E2EA22E26\", \"size\": 3782}]}\n",
```
