### PR TITLE
fix(logwriter): remove default prefix

### DIFF
--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -107,7 +107,7 @@ module "logwriter" {
 | <a name="input_log_group_name_prefixes"></a> [log\_group\_name\_prefixes](#input\_log\_group\_name\_prefixes) | Subscribe to CloudWatch log groups matching any of the provided prefixes.<br>To subscribe to all log groups use the wildcard operator *. | `list(string)` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for resources. | `string` | n/a | yes |
 | <a name="input_num_workers"></a> [num\_workers](#input\_num\_workers) | Maximum number of concurrent workers when processing log groups. | `number` | `null` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | Optional prefix to write log records to. | `string` | `"cloudwatchlogs/"` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Optional prefix to write log records to. | `string` | `""` | no |
 | <a name="input_sam_release_version"></a> [sam\_release\_version](#input\_sam\_release\_version) | Release version for SAM apps as defined on github.com/observeinc/aws-sam-apps. | `string` | `null` | no |
 | <a name="input_verbosity"></a> [verbosity](#input\_verbosity) | Logging verbosity for Lambda. Highest log verbosity is 9. | `number` | `null` | no |
 

--- a/modules/logwriter/variables.tf
+++ b/modules/logwriter/variables.tf
@@ -28,7 +28,7 @@ variable "prefix" {
   description = "Optional prefix to write log records to."
   type        = string
   nullable    = false
-  default     = "cloudwatchlogs/"
+  default     = ""
 }
 
 variable "buffering_interval" {

--- a/modules/stack/logwriter.tf
+++ b/modules/stack/logwriter.tf
@@ -4,7 +4,6 @@ module "logwriter" {
 
   name       = "${var.name}-logwriter"
   bucket_arn = aws_s3_bucket.this.arn
-  prefix     = "cloudwatchlogs/"
 
   log_group_name_patterns = var.logwriter.log_group_name_patterns
   log_group_name_prefixes = var.logwriter.log_group_name_prefixes


### PR DESCRIPTION
This behavior predates changes in the forwarder lambda which match on path under `AWSLogs/`.