### PR TITLE
fix(logwriter): subscribe on log group creation

### DIFF
--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -27,6 +27,8 @@ This app is specifically to register new cloudwatch log groups for the `logwrite
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_role.scheduler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.subscriber](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/modules/subscriber/eventbridge.tf
+++ b/modules/subscriber/eventbridge.tf
@@ -1,0 +1,39 @@
+resource "aws_cloudwatch_event_rule" "discovery" {
+  count       = local.has_discovery_rate ? 1 : 0
+  name_prefix = local.name_prefix
+  description = "Subscribe new log groups. Requires CloudTrail in target region."
+  state       = "ENABLED"
+
+  event_pattern = <<-EOF
+    {
+      "source": ["aws.logs"],
+      "detail-type": ["AWS API Call via CloudTrail"],
+      "detail": {
+        "eventSource": ["logs.amazonaws.com"],
+        "eventName": ["CreateLogGroup"]
+      }
+    }
+  EOF
+}
+
+resource "aws_cloudwatch_event_target" "discovery" {
+  count = local.has_discovery_rate ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.discovery[0].name
+  arn   = aws_sqs_queue.queue.arn
+
+  input_transformer {
+    input_paths = {
+      logGroupName = "$.detail.requestParameters.logGroupName"
+    }
+
+    input_template = jsonencode({
+      "subscribe" : {
+        "logGroups" : [
+          {
+            "logGroupName" : "<logGroupName>"
+          }
+        ]
+      }
+    })
+  }
+}


### PR DESCRIPTION
This commit adds an eventbridge rule to trigger the subscriber lambda on log group creation. This functionality was missing from terraform, but correctly implemented in cloudformation.