### PR TITLE
fix(subscriber): replace scheduler on variable changes

### DIFF
--- a/modules/subscriber/scheduler.tf
+++ b/modules/subscriber/scheduler.tf
@@ -19,4 +19,10 @@ resource "aws_scheduler_schedule" "discovery_schedule" {
       }
     })
   }
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_lambda_function.subscriber,
+    ]
+  }
 }


### PR DESCRIPTION
We want discovery to be re-run when input variables change. To do so, we can simply replace the scheduler every time the lambda is updated.