### PR TITLE
fix(externalrole): adjust outputs.

### DIFF
--- a/modules/externalrole/README.md
+++ b/modules/externalrole/README.md
@@ -70,5 +70,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_role"></a> [role](#output\_role) | IAM role to be assummed by Observe |
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN for IAM role to be assumed by Observe |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/externalrole/outputs.tf
+++ b/modules/externalrole/outputs.tf
@@ -1,4 +1,4 @@
-output "role" {
-  description = "IAM role to be assummed by Observe"
-  value       = aws_iam_role.this
+output "arn" {
+  description = "ARN for IAM role to be assumed by Observe"
+  value       = aws_iam_role.this.arn
 }


### PR DESCRIPTION
Returning an `arn` rather than a `role` reduces the stuttering when referring to the `externalrole` module, e.g: `module.metrics_role.arn` vs `module.metrics_role.role.arn`.