### PR TITLE
feat: Update to use aws_partition for AWS China (aws-cn) compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ terraform.tfvars
 tfplan
 
 .terraform.lock.hcl
+.idea

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ module "observe_collection" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda_log_subscription"></a> [lambda\_log\_subscription](#module\_lambda\_log\_subscription) | observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription | 2.2.0 |
+| <a name="module_lambda_log_subscription"></a> [lambda\_log\_subscription](#module\_lambda\_log\_subscription) | observeinc/kinesis-firehose/aws//modules/cloudwatch_logs_subscription | 2.3.0 |
 | <a name="module_observe_cloudwatch_logs_subscription"></a> [observe\_cloudwatch\_logs\_subscription](#module\_observe\_cloudwatch\_logs\_subscription) | observeinc/cloudwatch-logs-subscription/aws | 0.5.0 |
-| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.2.0 |
-| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.2.0 |
-| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.2.0 |
+| <a name="module_observe_cloudwatch_metrics"></a> [observe\_cloudwatch\_metrics](#module\_observe\_cloudwatch\_metrics) | observeinc/kinesis-firehose/aws//modules/cloudwatch_metrics | 2.3.0 |
+| <a name="module_observe_firehose_eventbridge"></a> [observe\_firehose\_eventbridge](#module\_observe\_firehose\_eventbridge) | observeinc/kinesis-firehose/aws//modules/eventbridge | 2.3.0 |
+| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | observeinc/kinesis-firehose/aws | 2.3.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | observeinc/lambda/aws | 3.6.0 |
 | <a name="module_observe_lambda_s3_bucket_subscription"></a> [observe\_lambda\_s3\_bucket\_subscription](#module\_observe\_lambda\_s3\_bucket\_subscription) | observeinc/lambda/aws//modules/s3_bucket_subscription | 3.6.0 |
 | <a name="module_observe_lambda_snapshot"></a> [observe\_lambda\_snapshot](#module\_observe\_lambda\_snapshot) | observeinc/lambda/aws//modules/snapshot | 3.6.0 |
@@ -119,6 +119,7 @@ module "observe_collection" {
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/examples/forwarder-kms/README.md
+++ b/examples/forwarder-kms/README.md
@@ -51,6 +51,7 @@ Note that this example may create resources which can cost money. Run terraform 
 | [observe_filedrop.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/filedrop) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.kms_default_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [observe_workspace.default](https://registry.terraform.io/providers/observeinc/observe/latest/docs/data-sources/workspace) | data source |
 
 ## Inputs

--- a/examples/forwarder-kms/main.tf
+++ b/examples/forwarder-kms/main.tf
@@ -5,6 +5,8 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "kms_default_key_policy" {
   statement {
     actions = [
@@ -12,7 +14,7 @@ data "aws_iam_policy_document" "kms_default_key_policy" {
     ]
     principals {
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+        "arn:${data.aws_partition.current.id}:iam::${data.aws_caller_identity.current.account_id}:root",
       ]
       type = "AWS"
     }
@@ -70,7 +72,7 @@ resource "observe_filedrop" "this" {
     provider {
       aws {
         region   = "us-west-2"
-        role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.name}"
+        role_arn = "arn:${data.aws_partition.current.id}:iam::${data.aws_caller_identity.current.account_id}:role/${local.name}"
       }
     }
   }

--- a/examples/stack-filedrop/README.md
+++ b/examples/stack-filedrop/README.md
@@ -43,6 +43,7 @@ Note that this example may create resources which can cost money. Run terraform 
 | [observe_datastream.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/datastream) | resource |
 | [observe_filedrop.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/filedrop) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [observe_workspace.default](https://registry.terraform.io/providers/observeinc/observe/latest/docs/data-sources/workspace) | data source |
 
 ## Inputs

--- a/examples/stack-filedrop/main.tf
+++ b/examples/stack-filedrop/main.tf
@@ -4,6 +4,8 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "observe_workspace" "default" {
   name = "Default"
 }
@@ -21,7 +23,7 @@ resource "observe_filedrop" "this" {
     provider {
       aws {
         region   = "us-west-2"
-        role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.name}"
+        role_arn = "arn:${data.aws_partition.current.id}:iam::${data.aws_caller_identity.current.account_id}:role/${local.name}"
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -8,3 +8,5 @@ locals {
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -76,6 +76,7 @@ No modules.
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/config/iam.tf
+++ b/modules/config/iam.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.bucket}",
+      "arn:${data.aws_partition.current.id}:s3:::${var.bucket}",
     ]
   }
 
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "writer" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.bucket}/${var.prefix}AWSLogs/*",
+      "arn:${data.aws_partition.current.id}:s3:::${var.bucket}/${var.prefix}AWSLogs/*",
     ]
   }
 }
@@ -71,5 +71,5 @@ data "aws_iam_policy_document" "notifications" {
 }
 
 data "aws_iam_policy" "service_role" {
-  arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+  arn = "arn:${data.aws_partition.current.id}:iam::aws:policy/service-role/AWS_ConfigRole"
 }

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -2,3 +2,5 @@ locals {
   all_supported          = length(local.include_resource_types) + length(var.exclude_resource_types) == 0
   include_resource_types = [for t in var.include_resource_types : t if t != "*"]
 }
+
+data "aws_partition" "current" {}

--- a/modules/externalrole/README.md
+++ b/modules/externalrole/README.md
@@ -56,6 +56,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/externalrole/main.tf
+++ b/modules/externalrole/main.tf
@@ -1,3 +1,5 @@
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "this" {
   name = var.name
 
@@ -9,7 +11,7 @@ resource "aws_iam_role" "this" {
         Effect = "Allow",
         Principal = {
           AWS = [
-            "arn:aws:iam::${var.observe_aws_account_id}:root"
+            "arn:${data.aws_partition.current.id}:iam::${var.observe_aws_account_id}:root"
           ]
         },
         Condition = {

--- a/modules/forwarder/iam.tf
+++ b/modules/forwarder/iam.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "reader" {
     actions = [
       "s3:ListBucket",
     ]
-    resources = [for name in var.source_bucket_names : "arn:aws:s3:::${name}"]
+    resources = [for name in var.source_bucket_names : "arn:${data.aws_partition.current.id}:s3:::${name}"]
   }
 
   statement {
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "reader" {
     # NOTE: this is a deviation from our CloudFormation template. In terraform
     # we can compute the product of two lists, allowing us to be strict as to what buckets and keys we grant the function read access for. 
     resources = [
-      for pair in setproduct(var.source_bucket_names, var.source_object_keys) : "arn:aws:s3:::${pair[0]}/${pair[1]}"
+      for pair in setproduct(var.source_bucket_names, var.source_object_keys) : "arn:${data.aws_partition.current.id}:s3:::${pair[0]}/${pair[1]}"
     ]
   }
 }

--- a/modules/forwarder/queue.tf
+++ b/modules/forwarder/queue.tf
@@ -1,7 +1,7 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
   region     = data.aws_region.current.name
-  sqs_arn    = "arn:aws:sqs:${local.region}:${local.account_id}:${var.name}"
+  sqs_arn    = "arn:${data.aws_partition.current.id}:sqs:${local.region}:${local.account_id}:${var.name}"
   enable_dlq = var.queue_max_receive_count > 0
 }
 
@@ -29,7 +29,7 @@ resource "aws_sqs_queue" "this" {
         },
         Condition = {
           ArnEquals = {
-            "aws:SourceArn" = [for name in var.source_bucket_names : "arn:aws:s3:::${name}"]
+            "aws:SourceArn" = [for name in var.source_bucket_names : "arn:${data.aws_partition.current.id}:s3:::${name}"]
           }
         }
       },

--- a/s3.tf
+++ b/s3.tf
@@ -1,7 +1,7 @@
 locals {
   create_s3_bucket = var.s3_bucket == null
   bucket_name      = local.create_s3_bucket ? "${local.name_prefix}${data.aws_region.current.name}-${random_string.this[0].id}" : var.s3_bucket.id
-  bucket_arn       = "arn:aws:s3:::${local.bucket_name}"
+  bucket_arn       = "arn:${data.aws_partition.current.id}:s3:::${local.bucket_name}"
   aws_logs_arn     = "${local.bucket_arn}/${local.s3_exported_prefix}AWSLogs/${data.aws_caller_identity.current.account_id}/*"
 
   s3_bucket = local.create_s3_bucket ? {


### PR DESCRIPTION
## What does this PR do?

Update to use [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) to retrieve AWS partition to deploy to China, which can have a value `aws` or  `aws-cn`.