### PR TITLE
feat: add aws_account_alias override

### DIFF
--- a/modules/config/alias.tf
+++ b/modules/config/alias.tf
@@ -1,9 +1,9 @@
 data "aws_iam_account_alias" "current" {
-  count = var.tag_account_alias ? 1 : 0
+  count = var.tag_account_alias && var.aws_account_alias == null ? 1 : 0
 }
 
 locals {
   tags = var.tag_account_alias ? {
-    "observeinc.com/accountalias" = data.aws_iam_account_alias.current[0].account_alias
+    "observeinc.com/accountalias" = var.aws_account_alias == null ? data.aws_iam_account_alias.current[0].account_alias : var.aws_account_alias
   } : {}
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -80,6 +80,15 @@ variable "sns_topic_arn" {
   nullable    = true
 }
 
+variable "aws_account_alias" {
+  description = <<-EOF
+    Override AWS account alias tag.
+  EOF
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 variable "tag_account_alias" {
   type        = bool
   description = <<-EOF

--- a/modules/configsubscription/alias.tf
+++ b/modules/configsubscription/alias.tf
@@ -1,9 +1,9 @@
 data "aws_iam_account_alias" "current" {
-  count = var.tag_account_alias ? 1 : 0
+  count = var.tag_account_alias && var.aws_account_alias == null ? 1 : 0
 }
 
 locals {
   tags = var.tag_account_alias ? {
-    "observeinc.com/accountalias" = data.aws_iam_account_alias.current[0].account_alias
+    "observeinc.com/accountalias" = var.aws_account_alias == null ? data.aws_iam_account_alias.current[0].account_alias : var.aws_account_alias
   } : {}
 }

--- a/modules/configsubscription/variables.tf
+++ b/modules/configsubscription/variables.tf
@@ -14,6 +14,15 @@ variable "name_prefix" {
   nullable    = false
 }
 
+variable "aws_account_alias" {
+  description = <<-EOF
+    Override AWS account alias tag.
+  EOF
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 variable "tag_account_alias" {
   type        = bool
   description = <<-EOF

--- a/modules/stack/config.tf
+++ b/modules/stack/config.tf
@@ -11,6 +11,7 @@ module "config" {
   delivery_frequency            = var.config.delivery_frequency
   include_global_resource_types = var.config.include_global_resource_types
   tag_account_alias             = var.config.tag_account_alias
+  aws_account_alias             = var.config.aws_account_alias
 
   depends_on = [aws_s3_bucket_notification.this]
 }

--- a/modules/stack/configsubscription.tf
+++ b/modules/stack/configsubscription.tf
@@ -6,5 +6,6 @@ module "configsubscription" {
   target_arn  = module.forwarder.queue_arn
 
   tag_account_alias = var.configsubscription.tag_account_alias
+  aws_account_alias = var.configsubscription.aws_account_alias
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -61,6 +61,7 @@ variable "config" {
     delivery_frequency            = optional(string)
     include_global_resource_types = optional(bool)
     tag_account_alias             = optional(bool)
+    aws_account_alias             = optional(string)
   })
   default = null
 }
@@ -72,6 +73,7 @@ variable "configsubscription" {
   type = object({
     delivery_bucket_name = string
     tag_account_alias    = optional(bool)
+    aws_account_alias    = optional(string)
   })
   default = null
 }


### PR DESCRIPTION
## What does this PR do?

Allows manually specifying the `"observeinc.com/accountalias"` tag.

Fixes #205 (excepting the upstream issue in the AWS provider still exists)

## Motivation

We don't have an AWS account alias defined, and would prefer not to have a publicly visible alias.

## Limitations

https://github.com/hashicorp/terraform-provider-aws/issues/29324 is still broken

## Testing

I've tested manually specifying and disabling the tag.

As we don't have an alias defined, we get an error and cannot verify the existing behavior.
