### PR TITLE
chore: Update tests to install Terraform on Ubuntu image

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -29,6 +29,15 @@ jobs:
         else
             echo "can-write=true" >> $GITHUB_OUTPUT
         fi
+    - name: Terraform min/max versions
+      id: minMax
+      uses: clowdhaus/terraform-min-max@v1.3.1
+      with:
+      directory: ${{ matrix.directory }}
+    - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ steps.minMax.outputs.minVersion }}
 
   prepare_matrix:
     needs: [permission_check]


### PR DESCRIPTION
## What does this PR do?

Updating tests to install Terraform on ubuntu as ubuntu-latest no longer includes Terraform. 

## Motivation

Pull requests have been failing due to Terraform missing on Ubuntu image:
```
terraform -chdir=./examples/forwarder-sns init -upgrade
make: terraform: No such file or directory
make: *** [Makefile:4: test-dir] Error 127
Error: Process completed with exit code 2.
```
See also https://github.com/actions/runner-images/issues/10796

