### PR TITLE
feat: Add filter and prefix to S3 aws_s3_bucket_lifecycle_configuration - OB-44161

### DIFF
--- a/modules/stack/s3.tf
+++ b/modules/stack/s3.tf
@@ -21,5 +21,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
       days = var.s3_bucket_lifecycle_expiration
     }
     status = "Enabled"
+    filter {
+      prefix = ""
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Addresses a warning emitted by the Terraform AWS Provider for the `aws_s3_bucket_lifecycle_configuration` module:
```
│ Warning: Invalid Attribute Combination
│
│   with module.observe.aws_s3_bucket_lifecycle_configuration.this,
│   on .terraform/modules/observe/modules/stack/s3.tf line 15, in resource "aws_s3_bucket_lifecycle_configuration" "this":
│   15: resource "aws_s3_bucket_lifecycle_configuration" "this" {
│
│ No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
│
│ This will be an error in a future version of the provider
```

## Testing

Validated that the example stack applies and functions as expected without warnings.
