### PR TITLE
feat: Explicitly set block_public_policy to true OB-44907

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -53,6 +53,7 @@ module "s3_bucket" {
   attach_lb_log_delivery_policy  = true
   attach_policy                  = true
   policy                         = data.aws_iam_policy_document.bucket.json
+  block_public_policy            = true
 
   tags = var.tags
 }


### PR DESCRIPTION
## What does this PR do?

This pull request explicitly sets the `block_public_policy` attribute to `true` for relevant S3 bucket public access configurations.

## Motivation

While block_public_policy may default to true in some environments, setting it explicitly ensures consistent behavior across all deployments and avoids relying on implicit defaults. This change strengthens the security posture by explicitly blocking any bucket policies that grant public access.

## Testing

Validated deployment continues to work as expected.