### PR TITLE
feat: Add vpc_config - IN-1061

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ module "observe_collection" {
 | <a name="input_lambda_subscribe_logs"></a> [lambda\_subscribe\_logs](#input\_lambda\_subscribe\_logs) | Whether to subscribe to the Lambda function's logs and deliver them from CloudWatch to Observe via Kinesis Firehose. | `bool` | `true` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | The amount of time that Lambda allows a function to run before stopping it.<br>The maximum allowed value is 900 seconds. | `number` | `120` | no |
 | <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Lambda version | `string` | `"arm64/latest"` | no |
+| <a name="input_lambda_vpc_config"></a> [lambda\_vpc\_config](#input\_lambda\_vpc\_config) | VPC configuration for Lambda function | <pre>object({<br>    security_groups = list(object({<br>      id = string<br>    }))<br>    subnets = list(object({<br>      arn = string<br>      id  = string<br>    }))<br>  })</pre> | `null` | no |
 | <a name="input_log_subscription_name"></a> [log\_subscription\_name](#input\_log\_subscription\_name) | Name for log subscription resources to be created | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for resources to be created | `string` | `"observe-collection"` | no |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |

--- a/lambda.tf
+++ b/lambda.tf
@@ -19,6 +19,7 @@ module "observe_lambda" {
   kms_key                       = var.lambda_kms_key
   retention_in_days             = var.retention_in_days
   dead_letter_queue_destination = var.dead_letter_queue_destination
+  vpc_config                    = var.lambda_vpc_config
 }
 
 module "observe_lambda_snapshot" {

--- a/variables.tf
+++ b/variables.tf
@@ -135,6 +135,21 @@ variable "dead_letter_queue_destination" {
   description = "Send failed events/function executions to a dead letter queue arn sns or sqs"
 }
 
+variable "lambda_vpc_config" {
+  description = "VPC configuration for Lambda function"
+  type = object({
+    security_groups = list(object({
+      id = string
+    }))
+    subnets = list(object({
+      arn = string
+      id  = string
+    }))
+  })
+  nullable = true
+  default  = null
+}
+
 variable "subscribed_s3_bucket_arns" {
   description = "List of additional S3 bucket ARNs to subscribe lambda to."
   type        = list(string)


### PR DESCRIPTION
## What does this PR do?

Adds VPC configuration support to allow deploying the Lambda function within a private VPC. The changes enable passing VPC configuration (subnets and security groups) through to the underlying `observeinc/lambda/aws` module.

- Added `lambda_vpc_config` variable to `variables.tf` that accepts VPC configuration with security groups and subnets
- Updated `lambda.tf` to pass the `lambda_vpc_config` variable to the `observe_lambda` module as `vpc_config`