### PR TITLE
feat: Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           # Important for pull request diff-awareness report
           fetch-depth: 0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Install Python
         uses: actions/setup-python@v6.2.0
       - name: Build matrix
@@ -37,12 +37,12 @@ jobs:
       OBSERVE_CUSTOMER: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Install Python
         uses: actions/setup-python@v6.2.0
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
         with:
           directory: ${{ matrix.directory }}
       - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
     outputs:
       minVersion: ${{ steps.minMax.outputs.minVersion }}
       maxVersion: ${{ steps.minMax.outputs.maxVersion }}
@@ -85,7 +85,7 @@ jobs:
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Install Python
         uses: actions/setup-python@v6.2.0
       - name: Install Terraform v${{ matrix.version }}
@@ -96,7 +96,7 @@ jobs:
         run: |
           pip install pre-commit
           curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.21.0/terraform-docs-v0.21.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r '.assets[] | select(.name | endswith("_linux_amd64.zip")) | .browser_download_url')" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -29,15 +29,6 @@ jobs:
         else
             echo "can-write=true" >> $GITHUB_OUTPUT
         fi
-    - name: Terraform min/max versions
-      id: minMax
-      uses: clowdhaus/terraform-min-max@v2.1.0
-      with:
-      directory: ${{ matrix.directory }}
-    - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
-      uses: hashicorp/setup-terraform@v4.0.0
-      with:
-        terraform_version: ${{ steps.minMax.outputs.minVersion }}
 
   prepare_matrix:
     needs: [permission_check]
@@ -46,14 +37,14 @@ jobs:
     outputs:
       matrix: ${{ steps.find_hcl_files.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
 
     - name: Setup the test matrix
       id: find_hcl_files
       run: |
         echo "matrix=$( find . -type d -name tests -print | sed 's:/[^/]*$::' | jq  -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
 
     - name: DCE Provision
       uses: observeinc/github-action-dce@1.0.1
@@ -87,7 +78,10 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: checkout
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
 
     - name: Integration test for ${{ matrix.testfile }}
       run: DIR=${{ matrix.testfile }} make test-dir

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -40,7 +40,7 @@ jobs:
 
       # Use Peter Evans Pull Request Action to create a pull request
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "feat: update dependencies"


### PR DESCRIPTION
## Summary

- Normalize `actions/checkout` from `v6.0.2` to `v6`
- Update `clowdhaus/terraform-min-max` from `v2.1.0` to `v3.0.1`
- Update `peter-evans/create-pull-request` from `v7` to `v8`

## Changes

| File | Change |
|---|---|
| `.github/workflows/pre-commit.yaml` | checkout `v6`, terraform-min-max `v3.0.1` |
| `.github/workflows/tests-integration.yaml` | checkout `v6`, terraform-min-max `v3.0.1` |
| `.github/workflows/update-deps.yaml` | create-pull-request `v8` |
| `.github/workflows/orca.yaml` | checkout `v6` |

## Testing
Deployed and validated changes.