### PR TITLE
fix: Clean up hardcoded source_account ID

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -96,7 +96,7 @@ jobs:
         run: |
           pip install pre-commit
           curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.21.0/terraform-docs-v0.21.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r '.assets[] | select(.name | test("linux_amd64\\.zip$")) | .browser_download_url')" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       can-write: ${{ steps.check.outputs.can-write }}
+      minVersion: ${{ steps.minMax.outputs.minVersion }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
@@ -29,11 +30,10 @@ jobs:
         else
             echo "can-write=true" >> $GITHUB_OUTPUT
         fi
+    - uses: actions/checkout@v6.0.2
     - name: Terraform min/max versions
       id: minMax
       uses: clowdhaus/terraform-min-max@v2.1.0
-      with:
-      directory: ${{ matrix.directory }}
     - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
       uses: hashicorp/setup-terraform@v4.0.0
       with:
@@ -88,6 +88,11 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v6.0.2
+
+    - name: Install Terraform v${{ needs.permission_check.outputs.minVersion }}
+      uses: hashicorp/setup-terraform@v4.0.0
+      with:
+        terraform_version: ${{ needs.permission_check.outputs.minVersion }}
 
     - name: Integration test for ${{ matrix.testfile }}
       run: DIR=${{ matrix.testfile }} make test-dir

--- a/examples/stack-filedrop/README.md
+++ b/examples/stack-filedrop/README.md
@@ -34,7 +34,7 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_stack"></a> [stack](#module\_stack) | ../..//modules/forwarder | n/a |
+| <a name="module_stack"></a> [stack](#module\_stack) | ../..//modules/stack | n/a |
 
 ## Resources
 

--- a/examples/stack-filedrop/main.tf
+++ b/examples/stack-filedrop/main.tf
@@ -31,10 +31,10 @@ resource "observe_filedrop" "this" {
 
 module "stack" {
   # Prefer using the hashicorp registry:
-  # source = "observeinc/collection/aws//modules/forwarder"
+  # source = "observeinc/collection/aws//modules/stack"
   # For validation purposes we will instead refer to a local version of the
   # module:
-  source = "../..//modules/forwarder"
+  source = "../..//modules/stack"
 
   name        = local.name
   destination = observe_filedrop.this.endpoint[0].s3[0]

--- a/examples/stack-http/README.md
+++ b/examples/stack-http/README.md
@@ -33,7 +33,7 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_stack"></a> [stack](#module\_stack) | ../..//modules/forwarder | n/a |
+| <a name="module_stack"></a> [stack](#module\_stack) | ../..//modules/stack | n/a |
 
 ## Resources
 

--- a/examples/stack-http/main.tf
+++ b/examples/stack-http/main.tf
@@ -23,10 +23,10 @@ resource "observe_datastream_token" "this" {
 
 module "stack" {
   # Prefer using the hashicorp registry:
-  # source = "observeinc/collection/aws//modules/forwarder"
+  # source = "observeinc/collection/aws//modules/stack"
   # For validation purposes we will instead refer to a local version of the
   # module:
-  source = "../..//modules/forwarder"
+  source = "../..//modules/stack"
 
   name = local.name
   destination = {

--- a/modules/stack/README.md
+++ b/modules/stack/README.md
@@ -178,7 +178,7 @@ You can additionally configure other submodules in this manner:
 | <a name="input_org_id"></a> [org\_id](#input\_org\_id) | Optional AWS Organizations ID. If set, adds an AllowAWSConfigFromOrg statement on the SNS topic that allows publishes by aws:PrincipalOrgID. Useful for AWS Control Tower integrations. | `string` | `null` | no |
 | <a name="input_s3_bucket_lifecycle_expiration"></a> [s3\_bucket\_lifecycle\_expiration](#input\_s3\_bucket\_lifecycle\_expiration) | Expiration in days for S3 objects in collection bucket | `number` | `4` | no |
 | <a name="input_sam_release_version"></a> [sam\_release\_version](#input\_sam\_release\_version) | Release version for SAM apps as defined on github.com/observeinc/aws-sam-apps. | `string` | `null` | no |
-| <a name="input_source_accounts"></a> [source\_accounts](#input\_source\_accounts) | List of AWS account IDs allowed to publish to the SNS topic via AWS Config. Useful for sub-accounts in AWS Organizations and Control Tower integrations.<br/>The current account ID is automatically included when this list is non-empty. | `list(string)` | <pre>[<br/>  "891377094505"<br/>]</pre> | no |
+| <a name="input_source_accounts"></a> [source\_accounts](#input\_source\_accounts) | List of AWS account IDs allowed to publish to the SNS topic via AWS Config. Useful for sub-accounts in AWS Organizations and Control Tower integrations.<br/>The current account ID is automatically included when this list is non-empty. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the resources. | `map(string)` | `{}` | no |
 | <a name="input_verbosity"></a> [verbosity](#input\_verbosity) | Logging verbosity for Lambda. Highest log verbosity is 9. | `number` | `null` | no |
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -156,7 +156,7 @@ variable "org_id" {
 # The current (audit) account ID is automatically included in the list.
 variable "source_accounts" {
   type        = list(string)
-  default     = ["891377094505"]
+  default     = []
   description = <<-EOF
     List of AWS account IDs allowed to publish to the SNS topic via AWS Config. Useful for sub-accounts in AWS Organizations and Control Tower integrations.
     The current account ID is automatically included when this list is non-empty.


### PR DESCRIPTION
## Summary
Removes hardcoded `source_accounts` from the defaults.

## Testing
    •    ✅ All pre-commit hooks pass
    •    ✅ Terraform fmt
    •    ✅ Terraform validate
    •    ✅ Terraform docs
    •    ✅ Terraform validate with tflint
    •    ✅ Check for merge conflicts