### PR TITLE
fix: align subscriber module with aws-sam-apps for correctness

### DIFF
--- a/modules/logwriter/tests/logwriter.tftest.hcl
+++ b/modules/logwriter/tests/logwriter.tftest.hcl
@@ -16,11 +16,17 @@ run "create_bucket" {
 
 run "install_logwriter" {
   variables {
-    name                    = run.setup.short
-    bucket_arn              = run.create_bucket.arn
-    discovery_rate          = "10 minutes"
-    filter_name             = "${run.setup.id}-filter"
-    log_group_name_patterns = ["${run.setup.short}"]
-    debug_endpoint          = "http://localhost:8080"
+    name                            = run.setup.short
+    bucket_arn                      = run.create_bucket.arn
+    discovery_rate                  = "10 minutes"
+    filter_name                     = "${run.setup.id}-filter"
+    log_group_name_patterns         = ["${run.setup.short}"]
+    exclude_log_group_name_patterns = ["^noisy-group"]
+    debug_endpoint                  = "http://localhost:8080"
+  }
+
+  assert {
+    condition     = output.subscriber != null
+    error_message = "subscriber should be created when patterns are set"
   }
 }

--- a/modules/stack/README.md
+++ b/modules/stack/README.md
@@ -223,7 +223,7 @@ module "stack" {
 | <a name="input_debug_endpoint"></a> [debug\_endpoint](#input\_debug\_endpoint) | Endpoint to send debugging telemetry to. Sets OTEL\_EXPORTER\_OTLP\_ENDPOINT environment variable for supported lambda functions. | `string` | `null` | no |
 | <a name="input_destination"></a> [destination](#input\_destination) | Destination filedrop | <pre>object({<br/>    arn    = optional(string, "")<br/>    bucket = optional(string, "")<br/>    prefix = optional(string, "")<br/>    # exclusively for backward compatible HTTP endpoint<br/>    uri = optional(string, "")<br/>  })</pre> | n/a | yes |
 | <a name="input_forwarder"></a> [forwarder](#input\_forwarder) | Variables for forwarder module. See ../forwarder/README.md for attribute details. | <pre>object({<br/>    source_bucket_names                      = optional(list(string), [])<br/>    source_object_keys                       = optional(list(string))<br/>    source_topic_arns                        = optional(list(string), [])<br/>    content_type_overrides                   = optional(list(object({ pattern = string, content_type = string })), [])<br/>    max_file_size                            = optional(number)<br/>    lambda_memory_size                       = optional(number)<br/>    lambda_timeout                           = optional(number)<br/>    lambda_env_vars                          = optional(map(string))<br/>    lambda_runtime                           = optional(string)<br/>    retention_in_days                        = optional(number)<br/>    queue_max_receive_count                  = optional(number)<br/>    queue_delay_seconds                      = optional(number)<br/>    queue_message_retention_seconds          = optional(number)<br/>    queue_batch_size                         = optional(number)<br/>    queue_maximum_batching_window_in_seconds = optional(number)<br/>    code_uri                                 = optional(string)<br/>    sam_release_version                      = optional(string)<br/>    cloudwatch_log_kms_key                   = optional(string)<br/>  })</pre> | `{}` | no |
-| <a name="input_logwriter"></a> [logwriter](#input\_logwriter) | Variables for AWS CloudWatch Logs collection. See ../logwriter/README.md for attribute details. | <pre>object({<br/>    log_group_name_patterns         = optional(list(string))<br/>    log_group_name_prefixes         = optional(list(string))<br/>    exclude_log_group_name_prefixes = optional(list(string))<br/>    buffering_interval              = optional(number)<br/>    buffering_size                  = optional(number)<br/>    filter_name                     = optional(string)<br/>    filter_pattern                  = optional(string)<br/>    num_workers                     = optional(number)<br/>    discovery_rate                  = optional(string, "24 hours")<br/>    lambda_memory_size              = optional(number)<br/>    lambda_timeout                  = optional(number)<br/>    lambda_env_vars                 = optional(map(string))<br/>    lambda_runtime                  = optional(string)<br/>    code_uri                        = optional(string)<br/>    sam_release_version             = optional(string)<br/>    retention_in_days               = optional(number)<br/>    cloudwatch_log_kms_key          = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_logwriter"></a> [logwriter](#input\_logwriter) | Variables for AWS CloudWatch Logs collection. See ../logwriter/README.md for attribute details. | <pre>object({<br/>    log_group_name_patterns         = optional(list(string))<br/>    log_group_name_prefixes         = optional(list(string))<br/>    exclude_log_group_name_patterns = optional(list(string))<br/>    buffering_interval              = optional(number)<br/>    buffering_size                  = optional(number)<br/>    filter_name                     = optional(string)<br/>    filter_pattern                  = optional(string)<br/>    num_workers                     = optional(number)<br/>    discovery_rate                  = optional(string, "24 hours")<br/>    lambda_memory_size              = optional(number)<br/>    lambda_timeout                  = optional(number)<br/>    lambda_env_vars                 = optional(map(string))<br/>    lambda_runtime                  = optional(string)<br/>    code_uri                        = optional(string)<br/>    sam_release_version             = optional(string)<br/>    retention_in_days               = optional(number)<br/>    cloudwatch_log_kms_key          = optional(string)<br/>  })</pre> | `null` | no |
 | <a name="input_metricstream"></a> [metricstream](#input\_metricstream) | Variables for AWS CloudWatch Metrics Stream collection. See ../metricstream/README.md for attribute details. | <pre>object({<br/>    include_filters        = optional(list(object({ namespace = string, metric_names = optional(list(string)) })))<br/>    exclude_filters        = optional(list(object({ namespace = string, metric_names = optional(list(string)) })))<br/>    buffering_interval     = optional(number)<br/>    buffering_size         = optional(number)<br/>    sam_release_version    = optional(string)<br/>    cloudwatch_log_kms_key = optional(string)<br/>    retention_in_days      = optional(number)<br/>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of role. Since this name must be unique within the<br/>account, it will be reused for most of the resources created by this<br/>module. | `string` | n/a | yes |
 | <a name="input_org_id"></a> [org\_id](#input\_org\_id) | Optional AWS Organizations ID. If set, adds an AllowAWSConfigFromOrg statement on the SNS topic that allows publishes by aws:PrincipalOrgID. Useful for AWS Control Tower integrations. | `string` | `null` | no |
@@ -245,3 +245,71 @@ module "stack" {
 | <a name="output_metricstream"></a> [metricstream](#output\_metricstream) | MetricStream module |
 | <a name="output_topic"></a> [topic](#output\_topic) | SNS topic subscribed to forwarder |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_config"></a> [config](#module\_config) | ../config | n/a |
+| <a name="module_configsubscription"></a> [configsubscription](#module\_configsubscription) | ../configsubscription | n/a |
+| <a name="module_forwarder"></a> [forwarder](#module\_forwarder) | ../forwarder | n/a |
+| <a name="module_logwriter"></a> [logwriter](#module\_logwriter) | ../logwriter | n/a |
+| <a name="module_metricstream"></a> [metricstream](#module\_metricstream) | ../metricstream | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_notification.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.sns_topic_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_config"></a> [config](#input\_config) | Variables for AWS Config collection. See ../config/README.md for attribute details. | <pre>object({<br/>    include_resource_types        = list(string)<br/>    exclude_resource_types        = optional(list(string))<br/>    delivery_frequency            = optional(string)<br/>    include_global_resource_types = optional(bool)<br/>    tag_account_alias             = optional(bool)<br/>  })</pre> | `null` | no |
+| <a name="input_configsubscription"></a> [configsubscription](#input\_configsubscription) | Variables for AWS Config subscription. See ../configsubscription/README.md for attribute details. | <pre>object({<br/>    delivery_bucket_name = string<br/>    tag_account_alias    = optional(bool)<br/>  })</pre> | `null` | no |
+| <a name="input_debug_endpoint"></a> [debug\_endpoint](#input\_debug\_endpoint) | Endpoint to send debugging telemetry to. Sets OTEL\_EXPORTER\_OTLP\_ENDPOINT environment variable for supported lambda functions. | `string` | `null` | no |
+| <a name="input_destination"></a> [destination](#input\_destination) | Destination filedrop | <pre>object({<br/>    arn    = optional(string, "")<br/>    bucket = optional(string, "")<br/>    prefix = optional(string, "")<br/>    # exclusively for backward compatible HTTP endpoint<br/>    uri = optional(string, "")<br/>  })</pre> | n/a | yes |
+| <a name="input_forwarder"></a> [forwarder](#input\_forwarder) | Variables for forwarder module. See ../forwarder/README.md for attribute details. | <pre>object({<br/>    source_bucket_names                      = optional(list(string), [])<br/>    source_object_keys                       = optional(list(string))<br/>    source_topic_arns                        = optional(list(string), [])<br/>    content_type_overrides                   = optional(list(object({ pattern = string, content_type = string })), [])<br/>    max_file_size                            = optional(number)<br/>    lambda_memory_size                       = optional(number)<br/>    lambda_timeout                           = optional(number)<br/>    lambda_env_vars                          = optional(map(string))<br/>    lambda_runtime                           = optional(string)<br/>    retention_in_days                        = optional(number)<br/>    queue_max_receive_count                  = optional(number)<br/>    queue_delay_seconds                      = optional(number)<br/>    queue_message_retention_seconds          = optional(number)<br/>    queue_batch_size                         = optional(number)<br/>    queue_maximum_batching_window_in_seconds = optional(number)<br/>    code_uri                                 = optional(string)<br/>    sam_release_version                      = optional(string)<br/>    cloudwatch_log_kms_key                   = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_logwriter"></a> [logwriter](#input\_logwriter) | Variables for AWS CloudWatch Logs collection. See ../logwriter/README.md for attribute details. | <pre>object({<br/>    log_group_name_patterns         = optional(list(string))<br/>    log_group_name_prefixes         = optional(list(string))<br/>    exclude_log_group_name_patterns = optional(list(string))<br/>    buffering_interval              = optional(number)<br/>    buffering_size                  = optional(number)<br/>    filter_name                     = optional(string)<br/>    filter_pattern                  = optional(string)<br/>    num_workers                     = optional(number)<br/>    discovery_rate                  = optional(string, "24 hours")<br/>    lambda_memory_size              = optional(number)<br/>    lambda_timeout                  = optional(number)<br/>    lambda_env_vars                 = optional(map(string))<br/>    lambda_runtime                  = optional(string)<br/>    code_uri                        = optional(string)<br/>    sam_release_version             = optional(string)<br/>    retention_in_days               = optional(number)<br/>    cloudwatch_log_kms_key          = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_metricstream"></a> [metricstream](#input\_metricstream) | Variables for AWS CloudWatch Metrics Stream collection. See ../metricstream/README.md for attribute details. | <pre>object({<br/>    include_filters        = optional(list(object({ namespace = string, metric_names = optional(list(string)) })))<br/>    exclude_filters        = optional(list(object({ namespace = string, metric_names = optional(list(string)) })))<br/>    buffering_interval     = optional(number)<br/>    buffering_size         = optional(number)<br/>    sam_release_version    = optional(string)<br/>    cloudwatch_log_kms_key = optional(string)<br/>    retention_in_days      = optional(number)<br/>  })</pre> | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of role. Since this name must be unique within the<br/>account, it will be reused for most of the resources created by this<br/>module. | `string` | n/a | yes |
+| <a name="input_org_id"></a> [org\_id](#input\_org\_id) | Optional AWS Organizations ID. If set, adds an AllowAWSConfigFromOrg statement on the SNS topic that allows publishes by aws:PrincipalOrgID. Useful for AWS Control Tower integrations. | `string` | `null` | no |
+| <a name="input_s3_bucket_lifecycle_expiration"></a> [s3\_bucket\_lifecycle\_expiration](#input\_s3\_bucket\_lifecycle\_expiration) | Expiration in days for S3 objects in collection bucket | `number` | `4` | no |
+| <a name="input_sam_release_version"></a> [sam\_release\_version](#input\_sam\_release\_version) | Release version for SAM apps as defined on github.com/observeinc/aws-sam-apps. | `string` | `null` | no |
+| <a name="input_source_accounts"></a> [source\_accounts](#input\_source\_accounts) | List of AWS account IDs allowed to publish to the SNS topic via AWS Config. Useful for sub-accounts in AWS Organizations and Control Tower integrations.<br/>The current account ID is automatically included when this list is non-empty. | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the resources. | `map(string)` | `{}` | no |
+| <a name="input_verbosity"></a> [verbosity](#input\_verbosity) | Logging verbosity for Lambda. Highest log verbosity is 9. | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | S3 bucket subscribed to forwarder |
+| <a name="output_config"></a> [config](#output\_config) | Config module |
+| <a name="output_configsubscription"></a> [configsubscription](#output\_configsubscription) | ConfigSubscription module |
+| <a name="output_forwarder"></a> [forwarder](#output\_forwarder) | Forwarder module |
+| <a name="output_logwriter"></a> [logwriter](#output\_logwriter) | LogWriter module |
+| <a name="output_metricstream"></a> [metricstream](#output\_metricstream) | MetricStream module |
+| <a name="output_topic"></a> [topic](#output\_topic) | SNS topic subscribed to forwarder |
+<!-- END_TF_DOCS -->

--- a/modules/stack/logwriter.tf
+++ b/modules/stack/logwriter.tf
@@ -5,25 +5,26 @@ module "logwriter" {
   name       = "${var.name}-logwriter"
   bucket_arn = aws_s3_bucket.this.arn
 
-  log_group_name_patterns = var.logwriter.log_group_name_patterns
-  log_group_name_prefixes = var.logwriter.log_group_name_prefixes
-  buffering_interval      = var.logwriter.buffering_interval
-  buffering_size          = var.logwriter.buffering_size
-  filter_name             = var.logwriter.filter_name
-  filter_pattern          = var.logwriter.filter_pattern
-  num_workers             = var.logwriter.num_workers
-  discovery_rate          = var.logwriter.discovery_rate
-  lambda_memory_size      = var.logwriter.lambda_memory_size
-  lambda_timeout          = var.logwriter.lambda_timeout
-  lambda_env_vars         = var.logwriter.lambda_env_vars
-  lambda_runtime          = var.logwriter.lambda_runtime
-  debug_endpoint          = var.debug_endpoint
-  verbosity               = var.verbosity
-  code_uri                = var.logwriter.code_uri
-  sam_release_version     = try(coalesce(var.logwriter.sam_release_version, var.sam_release_version), null)
-  retention_in_days       = var.logwriter.retention_in_days
-  cloudwatch_log_kms_key  = var.logwriter.cloudwatch_log_kms_key
-  tags                    = var.tags
+  log_group_name_patterns         = var.logwriter.log_group_name_patterns
+  log_group_name_prefixes         = var.logwriter.log_group_name_prefixes
+  exclude_log_group_name_patterns = var.logwriter.exclude_log_group_name_patterns
+  buffering_interval              = var.logwriter.buffering_interval
+  buffering_size                  = var.logwriter.buffering_size
+  filter_name                     = var.logwriter.filter_name
+  filter_pattern                  = var.logwriter.filter_pattern
+  num_workers                     = var.logwriter.num_workers
+  discovery_rate                  = var.logwriter.discovery_rate
+  lambda_memory_size              = var.logwriter.lambda_memory_size
+  lambda_timeout                  = var.logwriter.lambda_timeout
+  lambda_env_vars                 = var.logwriter.lambda_env_vars
+  lambda_runtime                  = var.logwriter.lambda_runtime
+  debug_endpoint                  = var.debug_endpoint
+  verbosity                       = var.verbosity
+  code_uri                        = var.logwriter.code_uri
+  sam_release_version             = try(coalesce(var.logwriter.sam_release_version, var.sam_release_version), null)
+  retention_in_days               = var.logwriter.retention_in_days
+  cloudwatch_log_kms_key          = var.logwriter.cloudwatch_log_kms_key
+  tags                            = var.tags
 
   depends_on = [aws_s3_bucket_notification.this]
 }

--- a/modules/stack/tests/collection.tftest.hcl
+++ b/modules/stack/tests/collection.tftest.hcl
@@ -36,7 +36,8 @@ run "install" {
     }
 
     logwriter = {
-      log_group_name_patterns = ["*"]
+      log_group_name_patterns         = ["*"]
+      exclude_log_group_name_patterns = ["^/aws/elasticbeanstalk"]
     }
 
     metricstream = {

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -84,7 +84,7 @@ variable "logwriter" {
   type = object({
     log_group_name_patterns         = optional(list(string))
     log_group_name_prefixes         = optional(list(string))
-    exclude_log_group_name_prefixes = optional(list(string))
+    exclude_log_group_name_patterns = optional(list(string))
     buffering_interval              = optional(number)
     buffering_size                  = optional(number)
     filter_name                     = optional(string)

--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -63,7 +63,7 @@ This app is specifically to register new cloudwatch log groups for the `logwrite
 | <a name="input_lambda_env_vars"></a> [lambda\_env\_vars](#input\_lambda\_env\_vars) | Environment variables to be passed into lambda. | `map(string)` | `{}` | no |
 | <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Memory size for lambda function. | `number` | `128` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Lambda runtime. | `string` | `"provided.al2023"` | no |
-| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `20` | no |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `120` | no |
 | <a name="input_log_group_name_patterns"></a> [log\_group\_name\_patterns](#input\_log\_group\_name\_patterns) | List of log group name patterns. A log group is subscribed if its name<br/>matches any pattern. Patterns matched using regexp.MatchString() (partial match),<br/>so a plain string like "/aws/lambda" matches any log group whose name<br/>contains that substring.<br/><br/>To subscribe to all log groups, use the special token "*". The "*"<br/>character selects all log groups.<br/><br/>Matching is regex-based, characters like "." are treated<br/>as regex metacharacters (matching any character), not literals.<br/><br/>Examples:<br/>  ["*"]                - subscribe to all log groups<br/>  ["/aws/lambda"]      - subscribe to any log group containing "/aws/lambda" | `list(string)` | `[]` | no |
 | <a name="input_log_group_name_prefixes"></a> [log\_group\_name\_prefixes](#input\_log\_group\_name\_prefixes) | List of log group name prefixes. A log group is subscribed if its name<br/>starts with any of the provided strings. Internally each prefix is<br/>converted to the regex "^<prefix>.*" and matched using<br/>regexp.MatchString().<br/><br/>To subscribe to all log groups, use the special token "*". The "*"<br/>character selects all log groups; it is not a glob wildcard.<br/><br/>Examples:<br/>  ["*"]           - subscribe to all log groups<br/>  ["/aws/lambda"] - subscribe to log groups whose names start with "/aws/lambda" | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for resources. | `string` | n/a | yes |
@@ -94,7 +94,7 @@ This app is specifically to register new cloudwatch log groups for the `logwrite
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 
@@ -142,7 +142,7 @@ This app is specifically to register new cloudwatch log groups for the `logwrite
 | <a name="input_lambda_env_vars"></a> [lambda\_env\_vars](#input\_lambda\_env\_vars) | Environment variables to be passed into lambda. | `map(string)` | `{}` | no |
 | <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Memory size for lambda function. | `number` | `128` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Lambda runtime. | `string` | `"provided.al2023"` | no |
-| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `20` | no |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout in seconds for lambda function. | `number` | `120` | no |
 | <a name="input_log_group_name_patterns"></a> [log\_group\_name\_patterns](#input\_log\_group\_name\_patterns) | List of log group name patterns. A log group is subscribed if its name<br/>matches any pattern. Patterns matched using regexp.MatchString() (partial match),<br/>so a plain string like "/aws/lambda" matches any log group whose name<br/>contains that substring.<br/><br/>To subscribe to all log groups, use the special token "*". The "*"<br/>character selects all log groups.<br/><br/>Matching is regex-based, characters like "." are treated<br/>as regex metacharacters (matching any character), not literals.<br/><br/>Examples:<br/>  ["*"]                - subscribe to all log groups<br/>  ["/aws/lambda"]      - subscribe to any log group containing "/aws/lambda" | `list(string)` | `[]` | no |
 | <a name="input_log_group_name_prefixes"></a> [log\_group\_name\_prefixes](#input\_log\_group\_name\_prefixes) | List of log group name prefixes. A log group is subscribed if its name<br/>starts with any of the provided strings. Internally each prefix is<br/>converted to the regex "^<prefix>.*" and matched using<br/>regexp.MatchString().<br/><br/>To subscribe to all log groups, use the special token "*". The "*"<br/>character selects all log groups; it is not a glob wildcard.<br/><br/>Examples:<br/>  ["*"]           - subscribe to all log groups<br/>  ["/aws/lambda"] - subscribe to log groups whose names start with "/aws/lambda" | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for resources. | `string` | n/a | yes |

--- a/modules/subscriber/iam.tf
+++ b/modules/subscriber/iam.tf
@@ -82,18 +82,20 @@ data "aws_iam_policy_document" "subscription_policy" {
 }
 
 resource "aws_iam_role" "scheduler" {
+  count              = local.has_discovery_rate ? 1 : 0
   name_prefix        = local.name_prefix
-  assume_role_policy = data.aws_iam_policy_document.scheduler_assume_role_policy.json
+  assume_role_policy = data.aws_iam_policy_document.scheduler_assume_role_policy[0].json
 
   inline_policy {
     name   = "queue"
-    policy = data.aws_iam_policy_document.scheduler_queue.json
+    policy = data.aws_iam_policy_document.scheduler_queue[0].json
   }
 
   tags = var.tags
 }
 
 data "aws_iam_policy_document" "scheduler_assume_role_policy" {
+  count = local.has_discovery_rate ? 1 : 0
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -105,6 +107,7 @@ data "aws_iam_policy_document" "scheduler_assume_role_policy" {
 }
 
 data "aws_iam_policy_document" "scheduler_queue" {
+  count = local.has_discovery_rate ? 1 : 0
   statement {
     effect = "Allow"
     actions = [

--- a/modules/subscriber/lambda.tf
+++ b/modules/subscriber/lambda.tf
@@ -1,6 +1,12 @@
 resource "aws_lambda_event_source_mapping" "subscriber_sqs" {
-  event_source_arn = aws_sqs_queue.queue.arn
-  function_name    = aws_lambda_function.subscriber.arn
+  event_source_arn        = aws_sqs_queue.queue.arn
+  function_name           = aws_lambda_function.subscriber.arn
+  batch_size              = 1
+  function_response_types = ["ReportBatchItemFailures"]
+
+  scaling_config {
+    maximum_concurrency = 2
+  }
 }
 
 resource "aws_lambda_function" "subscriber" {
@@ -24,7 +30,6 @@ resource "aws_lambda_function" "subscriber" {
       EXCLUDE_LOG_GROUP_NAME_PATTERNS = join(",", var.exclude_log_group_name_patterns)
       ROLE_ARN                        = var.destination_iam_arn
       QUEUE_URL                       = aws_sqs_queue.queue.id
-      VERBOSITY                       = 9
       NUM_WORKERS                     = var.num_workers
       OTEL_EXPORTER_OTLP_ENDPOINT     = var.debug_endpoint
       OTEL_TRACES_EXPORTER            = var.debug_endpoint == "" ? "none" : "otlp"

--- a/modules/subscriber/scheduler.tf
+++ b/modules/subscriber/scheduler.tf
@@ -11,7 +11,7 @@ resource "aws_scheduler_schedule" "discovery_schedule" {
 
   target {
     arn      = aws_sqs_queue.queue.arn
-    role_arn = aws_iam_role.scheduler.arn
+    role_arn = aws_iam_role.scheduler[0].arn
     input = jsonencode({
       discover = {
         logGroupNamePatterns = var.log_group_name_patterns

--- a/modules/subscriber/tests/subscriber.tftest.hcl
+++ b/modules/subscriber/tests/subscriber.tftest.hcl
@@ -1,0 +1,33 @@
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+}
+
+run "create_bucket" {
+  module {
+    source = "../testing/s3_bucket"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+run "install_logwriter_no_discovery" {
+  module {
+    source = "../../modules/logwriter"
+  }
+
+  variables {
+    name                    = run.setup.short
+    bucket_arn              = run.create_bucket.arn
+    filter_name             = "${run.setup.id}-filter"
+    log_group_name_patterns = ["${run.setup.short}"]
+  }
+
+  assert {
+    condition     = output.subscriber != null
+    error_message = "subscriber should be created when patterns are set"
+  }
+}

--- a/modules/subscriber/variables.tf
+++ b/modules/subscriber/variables.tf
@@ -150,7 +150,7 @@ variable "lambda_timeout" {
   description = "Timeout in seconds for lambda function."
   type        = number
   nullable    = false
-  default     = 20
+  default     = 120
 }
 
 variable "lambda_env_vars" {


### PR DESCRIPTION
## What does this PR do?

- Fix exclusion passthrough: rename stack variable from exclude_log_group_name_prefixes to exclude_log_group_name_patterns and wire it through to the logwriter module (was silently dropped)
- Remove duplicate VERBOSITY=9 env var in subscriber Lambda
- Add batch_size=1, ReportBatchItemFailures, and MaximumConcurrency=2 to SQS event source mapping to match SAM behavior
- Bump default subscriber Lambda timeout from 20s to 120s to match SAM
- Gate scheduler IAM role on discovery_rate to avoid unused resources
- Add subscriber integration test and extend logwriter/stack tests

Made-with: Cursor

## Testing
- Add exclude_log_group_name_patterns to the logwriter block, which tests that this variable is passed through correctly.
- Existing tests cover other fixes
- Add modules/subscriber/tests/subscriber.tftest.hcl, tests deploying the subscriber without a discovery rate, to verify the scheduler role and schedule are not created