### PR TITLE
ci: replace DCE with direct AWS credentials in integration tests

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -86,6 +86,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+      - name: Free disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "Disk space after cleanup:"
+          df -h
       - name: Install Python
         uses: actions/setup-python@v6.2.0
       - name: Install Terraform v${{ matrix.version }}

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -44,18 +44,6 @@ jobs:
       run: |
         echo "matrix=$( find . -type d -name tests -print | sed 's:/[^/]*$::' | jq  -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
-    - uses: actions/checkout@v6.0.2
-
-    - name: DCE Provision
-      uses: observeinc/github-action-dce@1.0.1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        budget-amount: ${{ vars.BUDGET_AMOUNT }}
-        budget-currency: 'USD'
-        expiry: '30m'
-        email: 'joao+gha@observeinc.com'
-
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
@@ -70,12 +58,12 @@ jobs:
       matrix:
         testfile: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
     steps:
-    - name: DCE Use
-      id: dce_setup
-      uses: observeinc/github-action-dce@1.0.1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
 
     - name: checkout
       uses: actions/checkout@v6.0.2
@@ -95,16 +83,4 @@ jobs:
       run: DIR=${{ matrix.testfile }} make test-dir
       env:
         AWS_REGION: us-west-2
-
-  cleanup:
-    needs: [permission_check, test-integration]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-    - name: DCE Cleanup
-      if: needs.permission_check.outputs.can-write == 'true'
-      uses: observeinc/github-action-dce@1.0.1
-      with:
-        action-type: 'decommission'
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        TF_VAR_test_run_id: ${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ module "observe_collection" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -193,7 +193,7 @@ Apache 2 Licensed. See LICENSE for full details.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -14,4 +14,6 @@ resource "aws_cloudtrail" "trail" {
       exclude_management_event_sources = var.cloudtrail_exclude_management_event_sources
     }
   }
+
+  depends_on = [module.s3_bucket]
 }

--- a/examples/forwarder-kms/README.md
+++ b/examples/forwarder-kms/README.md
@@ -21,9 +21,10 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_observe"></a> [observe](#requirement\_observe) | ~> 0.14 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
@@ -31,6 +32,7 @@ Note that this example may create resources which can cost money. Run terraform 
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_observe"></a> [observe](#provider\_observe) | ~> 0.14 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -49,6 +51,7 @@ Note that this example may create resources which can cost money. Run terraform 
 | [aws_s3_bucket_server_side_encryption_configuration.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [observe_datastream.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/datastream) | resource |
 | [observe_filedrop.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/filedrop) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.kms_default_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -56,7 +59,9 @@ Note that this example may create resources which can cost money. Run terraform 
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/forwarder-kms/main.tf
+++ b/examples/forwarder-kms/main.tf
@@ -1,6 +1,17 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name        = basename(abspath(path.root))
-  name_prefix = "${local.name}-"
+  example           = basename(abspath(path.root))
+  run_suffix        = coalesce(var.test_run_id, random_string.run.result)
+  run_short         = substr(local.run_suffix, max(0, length(local.run_suffix) - 8), 8)
+  name              = "tac-${local.run_suffix}-${local.example}"
+  bucket_prefix     = substr("t-${local.run_short}-${substr(local.example, 0, 22)}-", 0, 37)
+  bucket_prefix_src = substr("${trimsuffix(local.bucket_prefix, "-")}-src-", 0, 37)
+  bucket_prefix_dst = substr("${trimsuffix(local.bucket_prefix, "-")}-dst-", 0, 37)
 }
 
 data "aws_caller_identity" "current" {}
@@ -30,12 +41,12 @@ resource "aws_kms_key" "source" {
 }
 
 resource "aws_s3_bucket" "source" {
-  bucket_prefix = "${local.name_prefix}-source"
+  bucket_prefix = local.bucket_prefix_src
   force_destroy = true
 }
 
 resource "aws_s3_bucket" "destination" {
-  bucket_prefix = "${local.name_prefix}-destination"
+  bucket_prefix = local.bucket_prefix_dst
   force_destroy = true
 }
 

--- a/examples/forwarder-kms/variables.tf
+++ b/examples/forwarder-kms/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/forwarder-kms/versions.tf
+++ b/examples/forwarder-kms/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
@@ -10,6 +10,10 @@ terraform {
     observe = {
       source  = "observeinc/observe"
       version = "~> 0.14"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/examples/forwarder-s3/README.md
+++ b/examples/forwarder-s3/README.md
@@ -29,14 +29,16 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -57,11 +59,14 @@ Note that this example may create resources which can cost money. Run terraform 
 | [aws_s3_bucket_notification.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.s3_to_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.s3_to_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/forwarder-s3/direct.tf
+++ b/examples/forwarder-s3/direct.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "direct" {
-  bucket_prefix = "${local.name_prefix}direct-"
+  bucket_prefix = substr("${trimsuffix(local.bucket_prefix, "-")}-dir-", 0, 37)
   force_destroy = true
 }
 

--- a/examples/forwarder-s3/eventbridge.tf
+++ b/examples/forwarder-s3/eventbridge.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "eventbridge" {
-  bucket_prefix = "${local.name_prefix}eventbridge-"
+  bucket_prefix = substr("${trimsuffix(local.bucket_prefix, "-")}-eb-", 0, 37)
   force_destroy = true
 }
 

--- a/examples/forwarder-s3/main.tf
+++ b/examples/forwarder-s3/main.tf
@@ -1,11 +1,21 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name        = basename(abspath(path.root))
-  name_prefix = "${local.name}-"
+  example       = basename(abspath(path.root))
+  run_suffix    = coalesce(var.test_run_id, random_string.run.result)
+  run_short     = substr(local.run_suffix, max(0, length(local.run_suffix) - 8), 8)
+  name          = "tac-${local.run_suffix}-${local.example}"
+  name_prefix   = "${local.name}-"
+  bucket_prefix = substr("t-${local.run_short}-${substr(local.example, 0, 22)}-", 0, 37)
 }
 
 # we'll write data to this bucket
 resource "aws_s3_bucket" "destination" {
-  bucket_prefix = "${local.name_prefix}dst-"
+  bucket_prefix = substr("${trimsuffix(local.bucket_prefix, "-")}-dst-", 0, 37)
   force_destroy = true
 }
 
@@ -21,6 +31,6 @@ module "forwarder" {
     bucket = aws_s3_bucket.destination.id
     prefix = ""
   }
-  source_bucket_names = ["${local.name_prefix}*"]
+  source_bucket_names = ["${local.bucket_prefix}*"]
   source_object_keys  = ["*"]
 }

--- a/examples/forwarder-s3/sns.tf
+++ b/examples/forwarder-s3/sns.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "sns" {
-  bucket_prefix = "${local.name_prefix}sns-"
+  bucket_prefix = substr("${trimsuffix(local.bucket_prefix, "-")}-sns-", 0, 37)
   force_destroy = true
 }
 

--- a/examples/forwarder-s3/variables.tf
+++ b/examples/forwarder-s3/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/forwarder-s3/versions.tf
+++ b/examples/forwarder-s3/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/examples/forwarder-sns/README.md
+++ b/examples/forwarder-sns/README.md
@@ -17,14 +17,16 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -39,10 +41,13 @@ Note that this example may create resources which can cost money. Run terraform 
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/forwarder-sns/main.tf
+++ b/examples/forwarder-sns/main.tf
@@ -1,6 +1,16 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name        = basename(abspath(path.root))
-  name_prefix = "${local.name}-"
+  example       = basename(abspath(path.root))
+  run_suffix    = coalesce(var.test_run_id, random_string.run.result)
+  run_short     = substr(local.run_suffix, max(0, length(local.run_suffix) - 8), 8)
+  name          = "tac-${local.run_suffix}-${local.example}"
+  name_prefix   = "${local.name}-"
+  bucket_prefix = substr("t-${local.run_short}-${substr(local.example, 0, 22)}-", 0, 37)
 }
 
 # We will subscribe this SNS topic
@@ -10,7 +20,7 @@ resource "aws_sns_topic" "this" {
 
 # To this S3 bucket
 resource "aws_s3_bucket" "this" {
-  bucket_prefix = local.name_prefix
+  bucket_prefix = local.bucket_prefix
 }
 
 # Via the forwarder

--- a/examples/forwarder-sns/variables.tf
+++ b/examples/forwarder-sns/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/forwarder-sns/versions.tf
+++ b/examples/forwarder-sns/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/examples/logwriter-auto-subscription/README.md
+++ b/examples/logwriter-auto-subscription/README.md
@@ -18,14 +18,16 @@ destroy when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -40,10 +42,13 @@ destroy when you don't need these resources.
 | [aws_cloudwatch_log_group.excluded](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.included](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/logwriter-auto-subscription/main.tf
+++ b/examples/logwriter-auto-subscription/main.tf
@@ -1,11 +1,22 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name        = basename(abspath(path.root))
+  example     = basename(abspath(path.root))
+  run_suffix  = coalesce(var.test_run_id, random_string.run.result)
+  run_short   = substr(local.run_suffix, max(0, length(local.run_suffix) - 8), 8)
+  name        = "tac-${local.run_suffix}-${local.example}"
   name_prefix = "${local.name}-"
+  # S3 bucket_prefix is limited to 37 characters; keep full name on logwriter/CW resources.
+  bucket_prefix = substr("t-${local.run_short}-${substr(local.example, 0, 22)}-", 0, 37)
 }
 
 # This is the bucket where data will be written to.
 resource "aws_s3_bucket" "this" {
-  bucket_prefix = local.name_prefix
+  bucket_prefix = local.bucket_prefix
   force_destroy = true
 }
 

--- a/examples/logwriter-auto-subscription/variables.tf
+++ b/examples/logwriter-auto-subscription/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/logwriter-auto-subscription/versions.tf
+++ b/examples/logwriter-auto-subscription/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/examples/logwriter-manual-subscription/README.md
+++ b/examples/logwriter-manual-subscription/README.md
@@ -18,14 +18,16 @@ destroy when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -40,10 +42,13 @@ destroy when you don't need these resources.
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_subscription_filter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/logwriter-manual-subscription/main.tf
+++ b/examples/logwriter-manual-subscription/main.tf
@@ -1,6 +1,17 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name        = basename(abspath(path.root))
+  example     = basename(abspath(path.root))
+  run_suffix  = coalesce(var.test_run_id, random_string.run.result)
+  run_short   = substr(local.run_suffix, max(0, length(local.run_suffix) - 8), 8)
+  name        = "tac-${local.run_suffix}-${local.example}"
   name_prefix = "${local.name}-"
+  # S3 bucket_prefix is limited to 37 characters; keep full name on logwriter/CW resources.
+  bucket_prefix = substr("t-${local.run_short}-${substr(local.example, 0, 22)}-", 0, 37)
 }
 
 # This is the log group we will collect data for.
@@ -10,7 +21,7 @@ resource "aws_cloudwatch_log_group" "this" {
 
 # This is the bucket where data will be written to.
 resource "aws_s3_bucket" "this" {
-  bucket_prefix = local.name_prefix
+  bucket_prefix = local.bucket_prefix
   force_destroy = true
 }
 

--- a/examples/logwriter-manual-subscription/variables.tf
+++ b/examples/logwriter-manual-subscription/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/logwriter-manual-subscription/versions.tf
+++ b/examples/logwriter-manual-subscription/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -37,7 +37,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {

--- a/examples/stack-filedrop/README.md
+++ b/examples/stack-filedrop/README.md
@@ -19,9 +19,10 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_observe"></a> [observe](#requirement\_observe) | ~> 0.14 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
@@ -29,6 +30,7 @@ Note that this example may create resources which can cost money. Run terraform 
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_observe"></a> [observe](#provider\_observe) | ~> 0.14 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -42,13 +44,16 @@ Note that this example may create resources which can cost money. Run terraform 
 |------|------|
 | [observe_datastream.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/datastream) | resource |
 | [observe_filedrop.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/filedrop) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [observe_workspace.default](https://registry.terraform.io/providers/observeinc/observe/latest/docs/data-sources/workspace) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/stack-filedrop/main.tf
+++ b/examples/stack-filedrop/main.tf
@@ -1,5 +1,13 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name = basename(abspath(path.root))
+  example    = basename(abspath(path.root))
+  run_suffix = coalesce(var.test_run_id, random_string.run.result)
+  name       = "tac-${local.run_suffix}-${local.example}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/examples/stack-filedrop/variables.tf
+++ b/examples/stack-filedrop/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/stack-filedrop/versions.tf
+++ b/examples/stack-filedrop/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
@@ -10,6 +10,10 @@ terraform {
     observe = {
       source  = "observeinc/observe"
       version = "~> 0.14"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/examples/stack-http/README.md
+++ b/examples/stack-http/README.md
@@ -19,15 +19,17 @@ Note that this example may create resources which can cost money. Run terraform 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_observe"></a> [observe](#requirement\_observe) | >= 0.14.10 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_observe"></a> [observe](#provider\_observe) | >= 0.14.10 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
@@ -41,12 +43,15 @@ Note that this example may create resources which can cost money. Run terraform 
 |------|------|
 | [observe_datastream.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/datastream) | resource |
 | [observe_datastream_token.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/resources/datastream_token) | resource |
+| [random_string.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [observe_ingest_info.this](https://registry.terraform.io/providers/observeinc/observe/latest/docs/data-sources/ingest_info) | data source |
 | [observe_workspace.default](https://registry.terraform.io/providers/observeinc/observe/latest/docs/data-sources/workspace) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_test_run_id"></a> [test\_run\_id](#input\_test\_run\_id) | Workflow run ID for CI (set via TF\_VAR\_test\_run\_id=github.run\_id). Omit locally for a random suffix. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/stack-http/main.tf
+++ b/examples/stack-http/main.tf
@@ -1,5 +1,13 @@
+resource "random_string" "run" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
-  name = basename(abspath(path.root))
+  example    = basename(abspath(path.root))
+  run_suffix = coalesce(var.test_run_id, random_string.run.result)
+  name       = "tac-${local.run_suffix}-${local.example}"
 
   token               = nonsensitive(observe_datastream_token.this.secret)
   collection_endpoint = trim(data.observe_ingest_info.this.collect_url, "https://")

--- a/examples/stack-http/variables.tf
+++ b/examples/stack-http/variables.tf
@@ -1,0 +1,6 @@
+variable "test_run_id" {
+  type        = string
+  description = "Workflow run ID for CI (set via TF_VAR_test_run_id=github.run_id). Omit locally for a random suffix."
+  default     = null
+  nullable    = true
+}

--- a/examples/stack-http/versions.tf
+++ b/examples/stack-http/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
@@ -10,6 +10,10 @@ terraform {
     observe = {
       source  = "observeinc/observe"
       version = ">= 0.14.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
     }
   }
 }

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.11"
 
   required_providers {
     github = {

--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -44,7 +44,7 @@ module "cloudtrail" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -50,7 +50,7 @@ module "config" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/configsubscription/README.md
+++ b/modules/configsubscription/README.md
@@ -45,7 +45,7 @@ module "stack" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers

--- a/modules/configsubscription/versions.tf
+++ b/modules/configsubscription/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/externalrole/README.md
+++ b/modules/externalrole/README.md
@@ -38,7 +38,7 @@ module "external_role" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers

--- a/modules/externalrole/versions.tf
+++ b/modules/externalrole/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/forwarder/README.md
+++ b/modules/forwarder/README.md
@@ -60,7 +60,7 @@ module "forwarder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers

--- a/modules/forwarder/versions.tf
+++ b/modules/forwarder/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {

--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -163,7 +163,7 @@ or `cloudwatch_api_rate_limit`.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers

--- a/modules/logwriter/versions.tf
+++ b/modules/logwriter/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/metricstream/README.md
+++ b/modules/metricstream/README.md
@@ -24,7 +24,7 @@ module "metric_stream" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers

--- a/modules/metricstream/versions.tf
+++ b/modules/metricstream/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/sam_asset/versions.tf
+++ b/modules/sam_asset/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {

--- a/modules/stack/README.md
+++ b/modules/stack/README.md
@@ -182,7 +182,7 @@ module "stack" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers

--- a/modules/stack/tests/collection.tftest.hcl
+++ b/modules/stack/tests/collection.tftest.hcl
@@ -38,6 +38,7 @@ run "install" {
     logwriter = {
       log_group_name_patterns         = ["*"]
       exclude_log_group_name_patterns = ["^/aws/elasticbeanstalk"]
+      lambda_timeout                  = 600
     }
 
     metricstream = {

--- a/modules/stack/versions.tf
+++ b/modules/stack/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -20,7 +20,7 @@ When provisioners are disabled, subscription management relies entirely on the E
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |

--- a/modules/subscriber/cleanup.tf
+++ b/modules/subscriber/cleanup.tf
@@ -20,8 +20,9 @@ resource "null_resource" "cleanup_on_destroy" {
   }
 
   provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
       set -euo pipefail
 
       if [ "${lookup(self.triggers, "enable_provisioners", "false")}" != "true" ]; then
@@ -152,7 +153,8 @@ resource "null_resource" "discovery_on_apply" {
   }
 
   provisioner "local-exec" {
-    command = <<-EOT
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
       set -euo pipefail
 
       if [ "${lookup(self.triggers, "enable_provisioners", "false")}" != "true" ]; then

--- a/modules/subscriber/versions.tf
+++ b/modules/subscriber/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.11"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 locals {
   create_s3_bucket = var.s3_bucket == null
-  bucket_name      = local.create_s3_bucket ? "${local.name_prefix}${data.aws_region.current.name}-${random_string.this[0].id}" : var.s3_bucket.id
+  bucket_name      = local.create_s3_bucket ? "${local.name_prefix}${data.aws_region.current.name}-${random_string.this[0].result}" : var.s3_bucket.id
   bucket_arn       = "arn:${data.aws_partition.current.id}:s3:::${local.bucket_name}"
   aws_logs_arn     = "${local.bucket_arn}/${local.s3_exported_prefix}AWSLogs/${data.aws_caller_identity.current.account_id}/*"
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Replace DCE with direct AWS credentials in integration tests