### PR TITLE
fix: add SQS resource policies and disable local-exec provisioners by…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tfplan
 
 .terraform.lock.hcl
 .idea
+.snowflake

--- a/COMMIT-MESSAGE.txt
+++ b/COMMIT-MESSAGE.txt
@@ -1,0 +1,39 @@
+fix: add SQS resource policies and disable local-exec provisioners by default
+
+Add conditional resource-based SQS queue policies granting the Terraform caller sqs:SendMessage and sqs:GetQueueAttributes permissions, fixing AccessDenied errors in cross-account and federated environments (e.g., Spacelift, TFC). Policies are only created when provisioners are active.
+
+Provisioners activate automatically when wait_for_discovery_on_apply or cleanup_on_destroy is set to true. No separate enable flag needed.
+
+BREAKING CHANGE: wait_for_discovery_on_apply and cleanup_on_destroy now default to false. Discovery relies on the EventBridge scheduler by default. Set wait_for_discovery_on_apply=true and cleanup_on_destroy=true to activate provisioners introduced in https://github.com/observeinc/terraform-aws-collection/releases/tag/v2.34.0.
+
+## What does this PR do?
+
+Fixes AccessDenied errors when using `local-exec` provisioners in environments where the Terraform runner's identity lacks SQS permissions (e.g., Spacelift, TFC, OIDC federation). Changes `wait_for_discovery_on_apply` and `cleanup_on_destroy` to default to `false`, restoring the pre-v2.34.0 behavior where no AWS CLI is required on the Terraform runner.
+
+Key changes:
+- **SQS resource-based policies** added to the main queue and dead letter queue, granting the Terraform caller (`data.aws_caller_identity.current.arn`) `sqs:SendMessage` and `sqs:GetQueueAttributes`. Only created when provisioners are active.
+- **Default behavior change**: Both `wait_for_discovery_on_apply` and `cleanup_on_destroy` now default to `false`. Discovery relies solely on the EventBridge scheduler. No `local-exec` runs by default.
+- **Automatic provisioner activation**: Setting either variable to `true` automatically enables provisioners — derived via `local.enable_provisioners` in `subscriber/main.tf`.
+- **Updated documentation**: Logwriter README rewritten with behavior change notice, recommended settings by scale (up to 10K+ log groups), observed timings, and CloudWatch API limit guidance.
+
+## Motivation
+
+Customer reported in [OBSSD-3980](https://observe.atlassian.net/browse/OBSSD-3980) that v2.34.0 introduced `local-exec` provisioners that fail with `AccessDenied` in Spacelift. The provisioners use the `aws` CLI to call `sqs:SendMessage` and `sqs:GetQueueAttributes`, but the SQS queue resource policies only allowed the `events.amazonaws.com` service principal — not the Terraform runner's identity.
+
+Tracked in [OB-60351](https://observe.atlassian.net/browse/OB-60351).
+
+## Limitations
+
+- When provisioners are disabled (default), there is no immediate discovery on `terraform apply`. Subscriptions are reconciled on the next EventBridge scheduler run (`discovery_rate`).
+- When provisioners are disabled (default), `terraform destroy` does not clean up subscription filters. Orphaned filters remain on log groups pointing to the deleted Firehose. See [Deleting existing subscriptions on uninstall](https://github.com/observeinc/aws-sam-apps/blob/main/docs/logwriter.md#deleting-existing-subscriptions-on-uninstall).
+- `data.aws_caller_identity.current.arn` may not match the actual CLI caller in some complex cross-account assume-role chains where the provider and CLI use different credential paths.
+
+## Testing
+
+- Deployed to test environment (account 460044344528, us-east-1) with ~3,000 log groups
+- Verified discovery with multiple pattern/prefix/exclusion combinations (patterns=`["jdd"]`, `["jddz"]`; prefixes=`["/aws/lambda/"]`, `["/aws/ecs/"]`; excludes=`["logsub"]`)
+- Verified destroy-time cleanup removes all subscription filters when `cleanup_on_destroy=true`
+- Verified default behavior (both `false`): no `local-exec` runs, no AWS CLI required, EventBridge scheduler handles discovery
+- Verified behavior matches v2.33.0 defaults (no apply-time discovery, no destroy-time cleanup)
+- `terraform validate` passes for both subscriber and logwriter modules
+- No changes required to aws-sam-apps

--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -52,45 +52,57 @@ module "logwriter" {
 }
 ```
 
-> **⚠️ Behavior Change for Existing Users**
+> **⚠️ Behavior Change**
 >
-> Starting in version 2.33.0, when you update `log_group_name_patterns`,
-> `log_group_name_prefixes`, or `exclude_log_group_name_patterns`, Terraform
-> will **wait by default** for the subscriber Lambda to reconcile subscriptions
-> (add new matches, remove old ones) before completing the apply. This ensures
-> your actual CloudWatch Log Group subscriptions match your declared configuration.
+> Starting in this version, `local-exec` provisioners are **disabled by default**.
+> The defaults for `wait_for_discovery_on_apply` and `cleanup_on_destroy` have
+> changed to `false`.
 >
-> **Previous behavior**: Pattern changes only updated the Lambda's environment
-> variables. Subscriptions were reconciled asynchronously on the next scheduled
-> discovery run (`discovery_rate` 24 hours by default).
+> **Default behavior**: Discovery only runs via the EventBridge scheduler
+> (`discovery_rate`). No AWS CLI is required on the Terraform runner. Destroy
+> does not clean up subscription filters automatically.
 >
-> **New behavior**: Pattern changes trigger immediate discovery with queue
-> polling (up to 20 minutes with stagnation checks).
->
-> To restore the previous fire-and-forget behavior, set:
+> **Opt-in for apply-time discovery and destroy-time cleanup**:
 > ```hcl
-> wait_for_discovery_on_apply = false
+> wait_for_discovery_on_apply = true
+> cleanup_on_destroy          = true
 > ```
+> This requires the AWS CLI on the Terraform runner. Provisioners activate
+> automatically when either variable is set to `true`.
 
 ### Subscription lifecycle management
 
 When dynamic subscription is enabled, the [subscriber](../subscriber/README.md)
-module uses **two** `null_resource`s so **pattern updates** do not run
-delete-all cleanup (see subscriber README for the full table).
+module uses two `null_resource`s for apply-time discovery and destroy-time
+cleanup. These are **disabled by default**.
+
+When `wait_for_discovery_on_apply = true` or `cleanup_on_destroy = true`:
 
 - **On `terraform apply`**: `null_resource.discovery_on_apply` queues a
   full-prune discovery via SQS. That reconciles subscriptions (adds and
   removes) to match current patterns and related settings. **`wait_for_discovery_on_apply`**
-  (default `true`) controls whether Terraform **waits** and polls the queue
-  (with stagnation and DLQ checks) until work completes; set it to `false` to
-  enqueue only and return.
+  controls whether Terraform **waits** and polls the queue until work
+  completes; set it to `false` to enqueue only and return.
 
 - **On `terraform destroy`**: `null_resource.cleanup_on_destroy` queues
-  delete-all cleanup and **always waits** (same polling guardrails, up to ~20
-  minutes) while `cleanup_on_destroy = true`, so the stack is not destroyed
-  while subscription removal is still in flight. Set **`cleanup_on_destroy = false`**
-  to skip that step entirely. This input does **not** affect apply-time
-  discovery.
+  delete-all cleanup and waits for completion when `cleanup_on_destroy = true`.
+  This removes all managed subscription filters before infrastructure teardown.
+
+When both are `false` (default):
+
+- Discovery runs only via the EventBridge scheduler (`discovery_rate`).
+  New subscriptions are added and stale ones removed on the next scheduled run.
+- No cleanup runs on destroy, see [Deleting existing subscriptions on uninstall](https://github.com/observeinc/aws-sam-apps/blob/main/docs/logwriter.md#deleting-existing-subscriptions-on-uninstall). Subscription filters pointing to the deleted
+  Firehose will remain but will fail silently (no data loss, but they occupy
+  a subscription filter slot on the log group).
+
+### Prerequisites
+
+The `local-exec` provisioners (when `wait_for_discovery_on_apply = true` or
+`cleanup_on_destroy = true`) require the **AWS CLI** on the Terraform runner. The SQS queue resource policies
+automatically grant the Terraform caller `sqs:SendMessage` and
+`sqs:GetQueueAttributes` permissions, so no additional IAM configuration is
+needed.
 
 ### Tuning for large environments
 
@@ -102,34 +114,49 @@ throughput and API rate limiting:
 | `sqs_batch_size` | `5` | Messages per Lambda invocation from SQS |
 | `sqs_maximum_concurrency` | `10` | Maximum concurrent subscriber Lambda invocations |
 | `lambda_reserved_concurrency` | `null` | Optional hard cap on Lambda concurrency |
+| `lambda_timeout` | `120` | Lambda timeout in seconds (max 900) |
+| `lambda_memory_size` | `128` | Lambda memory in MB |
 | `cloudwatch_api_rate_limit` | `8` | CloudWatch API requests/second per invocation |
 | `cloudwatch_api_burst` | `16` | CloudWatch API burst allowance per invocation |
+| `num_workers` | `1` | Concurrent workers per Lambda invocation |
+| `discovery_rate` | `""` | EventBridge schedule (e.g., `"24 hours"`, `"4 hours"`) |
 
-With the SQS-driven orchestration (`batch_size=5`, `maximum_concurrency=10`) and
-the 200-groups-per-invocation chunking, cleanup of ~1,700 subscription filters
-completes in approximately 10 minutes. The `MAX_WAIT_SECONDS=1200` (20 min)
-guardrail, stagnation detection, and DLQ monitoring ensure `terraform destroy`
-fails fast rather than hanging indefinitely.
+#### Recommended settings by scale
 
-**Observed timings** (us-east-1, ~3,000 log groups):
+| Log groups | `lambda_timeout` | `lambda_memory_size` | `num_workers` | `sqs_maximum_concurrency` | `discovery_rate` | Notes |
+|---|---|---|---|---|---|---|
+| < 500 | `120` (default) | `128` (default) | `1` | `10` | `"24 hours"` | Defaults work well |
+| 500 – 2,000 | `300` | `256` | `2` | `10` | `"12 hours"` | Increase timeout for larger scan |
+| 2,000 – 5,000 | `600` | `512` | `3` | `10` | `"4 hours"` | More memory for concurrent work |
+| 5,000 – 10,000 | `900` | `512` | `3` | `5` | `"4 hours"` | Reduce concurrency to avoid API throttling |
+| > 10,000 | `900` | `512` | `3` | `5` | `"60 minutes"` | Consider splitting by pattern/prefix |
 
-| Operation | Wall time | Notes |
+#### Observed timings
+
+Tested in us-east-1 with ~3,000 log groups:
+
+| Operation | Wall time | Configuration |
 |---|---|---|
-| `terraform apply` (full stack creation + discovery) | ~3 min | Resource creation dominates; discovery drain adds ~20s |
-| `terraform destroy` cleanup drain (~1,700 filters) | ~10 min | Queue stays at `in_flight=1` while Lambda processes batches |
-| `terraform destroy` total (cleanup + resource teardown) | ~16 min | Resource deletion adds ~6 min after cleanup completes |
+| Full discovery (EventBridge scheduled) | ~4 min | SQS fan-out with `batch_size=5`, `max_concurrency=10` |
+| Full discovery (apply-time, `wait_for_discovery_on_apply=true`) | ~4 min | Same, plus polling wait |
+| Cleanup on destroy (`cleanup_on_destroy=true`) | ~13 min | Single Lambda invocation processing all groups |
+| Terraform apply (full stack creation + discovery) | ~3 min | Resource creation dominates |
+| Terraform destroy (cleanup + resource teardown) | ~19 min | Cleanup ~13 min + resource deletion ~6 min |
 
-The apply phase is relatively fast regardless of log group count.
-The stagnation timeout in the provisioner scripts is based on **subscriber
-`lambda_timeout` × 2** (minimum 180s), not `discovery_rate`.
+**How discovery works**: Each Lambda invocation processes up to 200 log groups
+(paginated in batches of 50). If more groups remain, a continuation message is
+enqueued to SQS. With `sqs_maximum_concurrency=10` and `sqs_batch_size=5`,
+up to 10 Lambda invocations process groups in parallel, each handling 200
+groups per invocation. For 3,000 log groups, this means ~15 continuation
+messages processed across multiple concurrent Lambda invocations.
 
-### Prerequisites
-
-The subscription lifecycle provisioners use `local-exec` with the **AWS CLI**,
-which must be available on the machine running Terraform (local workstation,
-CI runner, etc.). The AWS CLI must be configured with credentials that have
-permission to call `sqs:SendMessage` and `sqs:GetQueueAttributes` on the
-subscriber queues.
+**CloudWatch API limits**: The subscriber Lambda rate-limits itself to
+`cloudwatch_api_rate_limit` requests/second (default 8) per invocation. With
+10 concurrent invocations, the effective aggregate rate is ~80 req/s. The
+[CloudWatch Logs API quotas](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
+allow 10 DescribeLogGroups and 10 DescribeSubscriptionFilters requests/second
+per account by default. If you see throttling, reduce `sqs_maximum_concurrency`
+or `cloudwatch_api_rate_limit`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -175,7 +202,7 @@ subscriber queues.
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | S3 Bucket ARN to write log records to. | `string` | n/a | yes |
 | <a name="input_buffering_interval"></a> [buffering\_interval](#input\_buffering\_interval) | Buffer incoming data for the specified period of time, in seconds, before<br/>delivering it to S3. | `number` | `60` | no |
 | <a name="input_buffering_size"></a> [buffering\_size](#input\_buffering\_size) | Buffer incoming data to the specified size, in MiBs, before delivering it<br/>to S3. | `number` | `1` | no |
-| <a name="input_cleanup_on_destroy"></a> [cleanup\_on\_destroy](#input\_cleanup\_on\_destroy) | If true, subscriber null\_resource.cleanup\_on\_destroy runs delete-all cleanup<br/>and waits on the queue during destroy. If false, skip that step. Does not<br/>affect apply-time discovery. | `bool` | `true` | no |
+| <a name="input_cleanup_on_destroy"></a> [cleanup\_on\_destroy](#input\_cleanup\_on\_destroy) | If true, subscriber null\_resource.cleanup\_on\_destroy runs delete-all cleanup<br/>and waits on the queue during destroy. If false, skip that step. Does not<br/>affect apply-time discovery. When true, requires the AWS CLI on the Terraform runner. | `bool` | `false` | no |
 | <a name="input_cloudwatch_api_burst"></a> [cloudwatch\_api\_burst](#input\_cloudwatch\_api\_burst) | Per-invocation burst size for CloudWatch API limiter in subscriber. | `number` | `null` | no |
 | <a name="input_cloudwatch_api_rate_limit"></a> [cloudwatch\_api\_rate\_limit](#input\_cloudwatch\_api\_rate\_limit) | Per-invocation CloudWatch API request rate limit (requests/second) for<br/>subscriber operations. | `number` | `null` | no |
 | <a name="input_cloudwatch_log_kms_key"></a> [cloudwatch\_log\_kms\_key](#input\_cloudwatch\_log\_kms\_key) | KMS key to use for cloudwatch log encryption. | `string` | `null` | no |
@@ -202,7 +229,7 @@ subscriber queues.
 | <a name="input_sqs_maximum_concurrency"></a> [sqs\_maximum\_concurrency](#input\_sqs\_maximum\_concurrency) | Maximum concurrent Lambda invokes for subscriber SQS event source mapping.<br/>Effective parallelism is also limited by lambda\_reserved\_concurrency when that is set lower. | `number` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the resources. | `map(string)` | `{}` | no |
 | <a name="input_verbosity"></a> [verbosity](#input\_verbosity) | Logging verbosity for Lambda. Highest log verbosity is 9. | `number` | `null` | no |
-| <a name="input_wait_for_discovery_on_apply"></a> [wait\_for\_discovery\_on\_apply](#input\_wait\_for\_discovery\_on\_apply) | If true, subscriber null\_resource.discovery\_on\_apply waits until the queue<br/>drains and fails on DLQ growth. If false, enqueue discovery only (no apply<br/>polling). Destroy-time cleanup behavior is separate. | `bool` | `true` | no |
+| <a name="input_wait_for_discovery_on_apply"></a> [wait\_for\_discovery\_on\_apply](#input\_wait\_for\_discovery\_on\_apply) | If true, subscriber null\_resource.discovery\_on\_apply waits until the queue<br/>drains and fails on DLQ growth. If false, enqueue discovery only (no apply<br/>polling). Destroy-time cleanup behavior is separate.<br/>When true, requires the AWS CLI on the Terraform runner. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/logwriter/variables.tf
+++ b/modules/logwriter/variables.tf
@@ -112,19 +112,20 @@ variable "wait_for_discovery_on_apply" {
     If true, subscriber null_resource.discovery_on_apply waits until the queue
     drains and fails on DLQ growth. If false, enqueue discovery only (no apply
     polling). Destroy-time cleanup behavior is separate.
+    When true, requires the AWS CLI on the Terraform runner.
   EOF
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "cleanup_on_destroy" {
   description = <<-EOF
     If true, subscriber null_resource.cleanup_on_destroy runs delete-all cleanup
     and waits on the queue during destroy. If false, skip that step. Does not
-    affect apply-time discovery.
+    affect apply-time discovery. When true, requires the AWS CLI on the Terraform runner.
   EOF
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "num_workers" {

--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -2,22 +2,18 @@
 
 This app is specifically to register new cloudwatch log groups for the `logwriter` app. It will scan over existing log groups on an interval and compare them to provided prefixes and patterns. If they match it will then register new subscriptions from the log group to a provided kinesis firehose data stream.
 
-## Subscription lifecycle (`local-exec` + SQS)
+## Subscription lifecycle
 
-Two `null_resource`s split **destroy-time cleanup** from **apply-time discovery** so pattern changes do not replace the destroy resource (which would run delete-all cleanup during replacement).
+Two `null_resource`s provide optional apply-time discovery and destroy-time cleanup via `local-exec` provisioners. **Both are disabled by default**.
 
-| Resource | When it runs | Triggers (summary) |
-|----------|----------------|---------------------|
-| `null_resource.cleanup_on_destroy` | **Destroy only** (`when = destroy` provisioner) | Infra: Lambda ARN, queue URLs, timeout, `cleanup_on_destroy` |
-| `null_resource.discovery_on_apply` | **Create** (after apply changes this resource) | Patterns/prefixes/excludes, filter name/pattern, Firehose/role ARNs, queues, `wait_for_discovery_on_apply` |
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `wait_for_discovery_on_apply` | `false` | When `true`, Terraform sends a discovery message via SQS and polls until complete. Automatically enables the apply provisioner. |
+| `cleanup_on_destroy` | `false` | When `true`, Terraform runs delete-all cleanup on destroy and waits for completion. Automatically enables the destroy provisioner. |
 
-**Destroy (`cleanup_on_destroy`)**  
-Queues a delete-all cleanup message and **polls until the main queue is empty** (stagnation and DLQ growth fail the run). That avoids tearing down the Lambda and queues while cleanup is still in flight, which would leave **orphaned subscription filters**. There is no fire-and-forget option for this path when `cleanup_on_destroy = true`; skipping cleanup entirely is `cleanup_on_destroy = false`.
+Provisioners activate automatically when either variable is set to `true`. When both are `false` (default), no `local-exec` runs and no AWS CLI is needed.
 
-**Apply (`discovery_on_apply`)**  
-Queues a fullyPrune discovery (reconcile adds and removals). If **`wait_for_discovery_on_apply`** is `true` (default), Terraform uses the same style of queue polling and DLQ checks until work finishes. Set **`wait_for_discovery_on_apply = false`** to only `SendMessage` and return without waiting.
-
-The input **`cleanup_on_destroy`** only gates the **destroy** provisioner on `null_resource.cleanup_on_destroy`; it does not disable apply-time discovery.
+When provisioners are disabled, subscription management relies entirely on the EventBridge scheduler (`discovery_rate`). New log groups matching the configured patterns are subscribed on the next scheduled run.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -56,11 +52,13 @@ The input **`cleanup_on_destroy`** only gates the **destroy** provisioner on `nu
 | [aws_scheduler_schedule.discovery_schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
 | [aws_sqs_queue.dead_letter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_sqs_queue_policy.dead_letter_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 | [aws_sqs_queue_policy.queue_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 | [null_resource.cleanup_on_destroy](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.discovery_on_apply](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dead_letter_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.pass_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -73,7 +71,7 @@ The input **`cleanup_on_destroy`** only gates the **destroy** provisioner on `nu
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cleanup_on_destroy"></a> [cleanup\_on\_destroy](#input\_cleanup\_on\_destroy) | If true, null\_resource.cleanup\_on\_destroy runs the destroy provisioner (queued delete-all cleanup and queue wait). If false, that step is skipped. Does not disable apply-time discovery. | `bool` | `true` | no |
+| <a name="input_cleanup_on_destroy"></a> [cleanup\_on\_destroy](#input\_cleanup\_on\_destroy) | If true, null\_resource.cleanup\_on\_destroy runs the destroy provisioner (queued delete-all cleanup and queue wait). If false, that step is skipped. Does not disable apply-time discovery. When true, requires the AWS CLI on the Terraform runner. | `bool` | `false` | no |
 | <a name="input_cloudwatch_api_burst"></a> [cloudwatch\_api\_burst](#input\_cloudwatch\_api\_burst) | Per-invocation burst size for CloudWatch API limiter. | `number` | `16` | no |
 | <a name="input_cloudwatch_api_rate_limit"></a> [cloudwatch\_api\_rate\_limit](#input\_cloudwatch\_api\_rate\_limit) | Per-invocation CloudWatch API request rate limit (requests/second). | `number` | `8` | no |
 | <a name="input_cloudwatch_log_kms_key"></a> [cloudwatch\_log\_kms\_key](#input\_cloudwatch\_log\_kms\_key) | KMS key to use for cloudwatch log encryption. | `string` | `null` | no |
@@ -101,7 +99,7 @@ The input **`cleanup_on_destroy`** only gates the **destroy** provisioner on `nu
 | <a name="input_sqs_maximum_concurrency"></a> [sqs\_maximum\_concurrency](#input\_sqs\_maximum\_concurrency) | Maximum concurrent Lambda invokes for subscriber SQS event source mapping. Effective parallelism is also limited by lambda\_reserved\_concurrency when that is set lower. | `number` | `10` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the resources. | `map(string)` | `{}` | no |
 | <a name="input_verbosity"></a> [verbosity](#input\_verbosity) | Logging verbosity for Lambda. Highest log verbosity is 9. | `number` | `1` | no |
-| <a name="input_wait_for_discovery_on_apply"></a> [wait\_for\_discovery\_on\_apply](#input\_wait\_for\_discovery\_on\_apply) | If true, null\_resource.discovery\_on\_apply blocks until the subscriber queue drains and fails if the DLQ grows. If false, only SendMessage runs (no polling on apply). Destroy-time cleanup polling is unchanged. | `bool` | `true` | no |
+| <a name="input_wait_for_discovery_on_apply"></a> [wait\_for\_discovery\_on\_apply](#input\_wait\_for\_discovery\_on\_apply) | If true, null\_resource.discovery\_on\_apply blocks until the subscriber queue drains and fails if the DLQ grows. If false, only SendMessage runs (no polling on apply). Destroy-time cleanup polling is unchanged. When true, requires the AWS CLI on the Terraform runner. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/subscriber/cleanup.tf
+++ b/modules/subscriber/cleanup.tf
@@ -11,11 +11,12 @@
 
 resource "null_resource" "cleanup_on_destroy" {
   triggers = {
-    function_arn       = aws_lambda_function.subscriber.arn
-    queue_url          = aws_sqs_queue.queue.id
-    dlq_url            = aws_sqs_queue.dead_letter.id
-    lambda_timeout     = tostring(var.lambda_timeout)
-    cleanup_on_destroy = tostring(var.cleanup_on_destroy)
+    function_arn        = aws_lambda_function.subscriber.arn
+    queue_url           = aws_sqs_queue.queue.id
+    dlq_url             = aws_sqs_queue.dead_letter.id
+    lambda_timeout      = tostring(var.lambda_timeout)
+    cleanup_on_destroy  = tostring(var.cleanup_on_destroy)
+    enable_provisioners = tostring(local.enable_provisioners)
   }
 
   provisioner "local-exec" {
@@ -23,8 +24,14 @@ resource "null_resource" "cleanup_on_destroy" {
     command = <<-EOT
       set -euo pipefail
 
-      if [ "${lookup(self.triggers, "cleanup_on_destroy", "true")}" != "true" ]; then
-        echo "Skipping cleanup during destroy (cleanup_on_destroy=false)." >&2
+      if [ "${lookup(self.triggers, "enable_provisioners", "false")}" != "true" ]; then
+        echo "Skipping all provisioner operations (enable_provisioners=false)." >&2
+        exit 0
+      fi
+
+      if [ "${lookup(self.triggers, "cleanup_on_destroy", "false")}" != "true" ]; then
+        echo "Skipping subscription filter cleanup during destroy (cleanup_on_destroy=false)." >&2
+        echo "WARNING: Subscription filters will remain and must be manually removed." >&2
         exit 0
       fi
 
@@ -133,6 +140,7 @@ resource "null_resource" "discovery_on_apply" {
     queue_url                       = aws_sqs_queue.queue.id
     dlq_url                         = aws_sqs_queue.dead_letter.id
     lambda_timeout                  = tostring(var.lambda_timeout)
+    enable_provisioners             = tostring(local.enable_provisioners)
     wait_for_discovery_on_apply     = tostring(var.wait_for_discovery_on_apply)
     log_group_name_patterns         = join(",", var.log_group_name_patterns)
     log_group_name_prefixes         = join(",", var.log_group_name_prefixes)
@@ -146,6 +154,11 @@ resource "null_resource" "discovery_on_apply" {
   provisioner "local-exec" {
     command = <<-EOT
       set -euo pipefail
+
+      if [ "${lookup(self.triggers, "enable_provisioners", "false")}" != "true" ]; then
+        echo "Skipping discovery on apply (provisioners disabled)." >&2
+        exit 0
+      fi
 
       REGION=$(echo ${self.triggers.function_arn} | cut -d: -f4)
       QUEUE_URL="${self.triggers.queue_url}"

--- a/modules/subscriber/main.tf
+++ b/modules/subscriber/main.tf
@@ -1,8 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  has_discovery_rate = var.discovery_rate != ""
-  name_prefix        = "${substr(var.name, 0, 37)}-"
+  has_discovery_rate  = var.discovery_rate != ""
+  enable_provisioners = var.wait_for_discovery_on_apply || var.cleanup_on_destroy
+  name_prefix         = "${substr(var.name, 0, 37)}-"
 
   code_uri      = var.code_uri != "" ? var.code_uri : yamldecode(module.sam_asset[0].body)["Resources"]["Subscriber"]["Properties"]["CodeUri"]
   parsed_s3_uri = regex("s3://(?P<bucket>[^/]+)/(?P<key>.+)", local.code_uri)

--- a/modules/subscriber/queue.tf
+++ b/modules/subscriber/queue.tf
@@ -37,4 +37,39 @@ data "aws_iam_policy_document" "queue" {
       values   = [data.aws_caller_identity.current.account_id]
     }
   }
+
+  dynamic "statement" {
+    for_each = local.enable_provisioners ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "sqs:SendMessage",
+        "sqs:GetQueueAttributes",
+      ]
+      resources = [aws_sqs_queue.queue.arn]
+      principals {
+        type        = "AWS"
+        identifiers = [data.aws_caller_identity.current.arn]
+      }
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "dead_letter_policy" {
+  count     = local.enable_provisioners ? 1 : 0
+  policy    = data.aws_iam_policy_document.dead_letter_queue[0].json
+  queue_url = aws_sqs_queue.dead_letter.id
+}
+
+data "aws_iam_policy_document" "dead_letter_queue" {
+  count = local.enable_provisioners ? 1 : 0
+  statement {
+    effect    = "Allow"
+    actions   = ["sqs:GetQueueAttributes"]
+    resources = [aws_sqs_queue.dead_letter.arn]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.arn]
+    }
+  }
 }

--- a/modules/subscriber/variables.tf
+++ b/modules/subscriber/variables.tf
@@ -121,17 +121,17 @@ variable "exclude_log_group_name_patterns" {
 }
 
 variable "wait_for_discovery_on_apply" {
-  description = "If true, null_resource.discovery_on_apply blocks until the subscriber queue drains and fails if the DLQ grows. If false, only SendMessage runs (no polling on apply). Destroy-time cleanup polling is unchanged."
+  description = "If true, null_resource.discovery_on_apply blocks until the subscriber queue drains and fails if the DLQ grows. If false, only SendMessage runs (no polling on apply). Destroy-time cleanup polling is unchanged. When true, requires the AWS CLI on the Terraform runner."
   type        = bool
   nullable    = false
-  default     = true
+  default     = false
 }
 
 variable "cleanup_on_destroy" {
-  description = "If true, null_resource.cleanup_on_destroy runs the destroy provisioner (queued delete-all cleanup and queue wait). If false, that step is skipped. Does not disable apply-time discovery."
+  description = "If true, null_resource.cleanup_on_destroy runs the destroy provisioner (queued delete-all cleanup and queue wait). If false, that step is skipped. Does not disable apply-time discovery. When true, requires the AWS CLI on the Terraform runner."
   type        = bool
   nullable    = false
-  default     = true
+  default     = false
 }
 
 variable "discovery_rate" {


### PR DESCRIPTION
Add conditional resource-based SQS queue policies granting the Terraform caller `sqs:SendMessage` and `sqs:GetQueueAttributes` permissions, fixing `AccessDenied` errors in cross-account and federated environments (e.g., Spacelift, TFC). Policies are only created when provisioners are active.

Provisioners activate automatically when `wait_for_discovery_on_apply` or `cleanup_on_destroy` is set to `true`. 

BREAKING CHANGE: `wait_for_discovery_on_apply` and `cleanup_on_destroy` now default to `false`. Discovery relies on the EventBridge scheduler by default. Set` wait_for_discovery_on_apply=true` and `cleanup_on_destroy=true` to activate provisioners introduced in https://github.com/observeinc/terraform-aws-collection/releases/tag/v2.34.0.

## What does this PR do?

Fixes AccessDenied errors when using `local-exec` provisioners in environments where the Terraform runner's identity lacks SQS permissions (e.g., Spacelift, TFC, OIDC federation). Changes `wait_for_discovery_on_apply` and `cleanup_on_destroy` to default to `false`, restoring the pre-v2.34.0 behavior where no AWS CLI is required on the Terraform runner.

Key changes:
- **SQS resource-based policies** added to the main queue and dead letter queue, granting the Terraform caller (`data.aws_caller_identity.current.arn`) `sqs:SendMessage` and `sqs:GetQueueAttributes`. Only created when provisioners are active.
- **Default behavior change**: Both `wait_for_discovery_on_apply` and `cleanup_on_destroy` now default to `false`. Discovery relies solely on the EventBridge scheduler. No `local-exec` runs by default.
- **Automatic provisioner activation**: Setting either variable to `true` automatically enables provisioners — derived via `local.enable_provisioners` in `subscriber/main.tf`.
- **Updated documentation**: Logwriter README rewritten with behavior change notice, recommended settings by scale (up to 10K+ log groups), observed timings, and CloudWatch API limit guidance.

## Motivation

Customer reported in `OBSSD-3980` that v2.34.0 introduced `local-exec` provisioners that fail with `AccessDenied` in Spacelift. The provisioners use the `aws` CLI to call `sqs:SendMessage` and `sqs:GetQueueAttributes`, but the SQS queue resource policies only allowed the `events.amazonaws.com` service principal — not the Terraform runner's identity.

Tracked in `OB-60351`.

## Limitations

- When provisioners are disabled (default), there is no immediate discovery on `terraform apply`. Subscriptions are reconciled on the next EventBridge scheduler run (`discovery_rate`).
- When provisioners are disabled (default), `terraform destroy` does not clean up subscription filters. Orphaned filters remain on log groups pointing to the deleted Firehose. See [Deleting existing subscriptions on uninstall](https://github.com/observeinc/aws-sam-apps/blob/main/docs/logwriter.md#deleting-existing-subscriptions-on-uninstall).
- `data.aws_caller_identity.current.arn` may not match the actual CLI caller in some complex cross-account assume-role chains where the provider and CLI use different credential paths.

## Testing

- Deployed to test environment (account 460044344528, us-east-1) with ~3,000 log groups
- Verified discovery with multiple pattern/prefix/exclusion combinations (patterns=`["jdd"]`, `["jddz"]`; prefixes=`["/aws/lambda/"]`, `["/aws/ecs/"]`; excludes=`["logsub"]`)
- Verified destroy-time cleanup removes all subscription filters when `cleanup_on_destroy=true`
- Verified default behavior (both `false`): no `local-exec` runs, no AWS CLI required, EventBridge scheduler handles discovery
- Verified behavior matches v2.33.0 defaults (no apply-time discovery, no destroy-time cleanup)
- `terraform validate` passes for both subscriber and logwriter modules
- No changes required to aws-sam-apps
