### PR TITLE
docs: clarify local-exec uses Terraform runner credentials

### DIFF
--- a/modules/logwriter/README.md
+++ b/modules/logwriter/README.md
@@ -99,10 +99,17 @@ When both are `false` (default):
 ### Prerequisites
 
 The `local-exec` provisioners (when `wait_for_discovery_on_apply = true` or
-`cleanup_on_destroy = true`) require the **AWS CLI** on the Terraform runner. The SQS queue resource policies
-automatically grant the Terraform caller `sqs:SendMessage` and
-`sqs:GetQueueAttributes` permissions, so no additional IAM configuration is
-needed.
+`cleanup_on_destroy = true`) require the **AWS CLI** on the Terraform runner.
+
+> **Important: the AWS CLI uses Terraform runner environment credentials — not the AWS provider credentials.**
+>
+> The provisioners shell out to the `aws` CLI, which resolves credentials from the **runner's OS environment** (environment variables like `AWS_ACCESS_KEY_ID`, `~/.aws/credentials`, or instance/container metadata). This is independent of the credentials configured in your `provider "aws"` block.
+>
+> In environments using Spacelift, Terraform Cloud/HCP Terraform with OIDC, GitHub Actions, HashiCorp Vault dynamic credentials, or AWS SSO, the provider credentials may be injected at the provider level but are **not** available as OS environment variables. This produces `sqs:SendMessage` or `sqs:GetQueueAttributes` access denied errors even though the provider is otherwise authorized.
+>
+> If you hit this issue, set both variables to `false` and let discovery run via the EventBridge scheduler instead.
+
+The SQS queue resource policies automatically grant the Terraform caller `sqs:SendMessage` and `sqs:GetQueueAttributes` permissions, so no additional IAM configuration is needed — provided the runner's AWS CLI credentials match the caller identity that Terraform uses.
 
 ### Tuning for large environments
 

--- a/modules/stack/README.md
+++ b/modules/stack/README.md
@@ -134,6 +134,31 @@ You can additionally configure other submodules in this manner:
 - the `configsubscription` [module](../configsubscription/README.md) enables subscribing to a pre-existing [AWS Config](https://aws.amazon.com/config/) install. 
 - the `metricstream` [module](../metricstream/README.md) enables [AWS Cloudwatch Metrics Stream](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html) collection. 
 
+### Log subscription and local-exec provisioners
+
+When `logwriter` is configured, two variables control optional apply-time discovery and destroy-time cleanup:
+
+| Variable | Default in stack module | Behavior |
+|---|---|---|
+| `wait_for_discovery_on_apply` | `true` | Terraform blocks on apply until subscription discovery completes |
+| `cleanup_on_destroy` | `true` | Terraform removes all subscription filters before destroying infrastructure |
+
+> **Important: these provisioners use Terraform runner environment credentials, not the AWS provider credentials.**
+>
+> When `wait_for_discovery_on_apply = true` or `cleanup_on_destroy = true`, the module runs `local-exec` provisioners that shell out to the `aws` CLI. The CLI resolves credentials from the **Terraform runner's OS environment** (environment variables like `AWS_ACCESS_KEY_ID`, `~/.aws/credentials`, or instance/container metadata) — completely independently of the credentials configured in your `provider "aws"` block.
+>
+> In many CI/CD and remote execution environments — Spacelift, Terraform Cloud/HCP Terraform with OIDC, GitHub Actions, HashiCorp Vault dynamic credentials, or AWS SSO — the AWS provider credentials are injected at the provider level but are **not** available as OS environment variables for child processes. This produces `sqs:SendMessage` or `sqs:GetQueueAttributes` access denied errors even though the provider itself is fully authorized.
+>
+> To disable the provisioners and avoid this issue, set both variables to `false`:
+> ```terraform
+> logwriter = {
+>   log_group_name_patterns         = ["*"]
+>   wait_for_discovery_on_apply     = false
+>   cleanup_on_destroy              = false
+> }
+> ```
+> With both set to `false`, no AWS CLI is needed on the runner. Subscription discovery runs via the EventBridge scheduler (`discovery_rate`). See the [logwriter module](../logwriter/README.md#subscription-lifecycle-management) for more details on lifecycle behavior.
+
 ## Migrating from the root module
 
 The root module (documented in the top-level [README](../../README.md)) is no longer maintained. This section describes how to migrate to the `stack` module.

--- a/modules/subscriber/README.md
+++ b/modules/subscriber/README.md
@@ -13,6 +13,12 @@ Two `null_resource`s provide optional apply-time discovery and destroy-time clea
 
 Provisioners activate automatically when either variable is set to `true`. When both are `false` (default), no `local-exec` runs and no AWS CLI is needed.
 
+> **Important: when enabled, these provisioners use Terraform runner environment credentials — not the AWS provider credentials.**
+>
+> The `local-exec` provisioners shell out to the `aws` CLI. The CLI resolves credentials from the **runner's OS environment** (environment variables like `AWS_ACCESS_KEY_ID`, `~/.aws/credentials`, or instance/container metadata). This is independent of the credentials configured in your `provider "aws"` block.
+>
+> In environments using Spacelift, Terraform Cloud/HCP Terraform with OIDC, GitHub Actions, HashiCorp Vault dynamic credentials, or AWS SSO, provider credentials may be injected at the provider level but are **not** available as OS environment variables. Setting either variable to `true` in these environments will produce `sqs:SendMessage` or `sqs:GetQueueAttributes` access denied errors even though the provider is authorized. Leave both at `false` (the default) to avoid this.
+
 When provisioners are disabled, subscription management relies entirely on the EventBridge scheduler (`discovery_rate`). New log groups matching the configured patterns are subscribed on the next scheduled run.
 
 <!-- BEGIN_TF_DOCS -->


### PR DESCRIPTION
## Summary

Updating documentation to be clearer around the `wait_for_discovery_on_apply` and `cleanup_on_destroy` variables
and their credential requirements.

### No functional changes

Documentation only — no Terraform resources, variables, or defaults were modified.