### PR TITLE
fix: use regional S3 endpoint in sam_asset to support opt-in regions

### DIFF
--- a/modules/sam_asset/main.tf
+++ b/modules/sam_asset/main.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_region" "current" {}
 
 data "http" "manifest" {
-  url = "https://observeinc-${data.aws_region.current.region}.s3.amazonaws.com/aws-sam-apps/${local.release_version}/${var.asset}"
+  url = "https://observeinc-${data.aws_region.current.region}.s3.${data.aws_region.current.region}.amazonaws.com/aws-sam-apps/${local.release_version}/${var.asset}"
 
   lifecycle {
     postcondition {


### PR DESCRIPTION
The global `s3.amazonaws.com` endpoint does not support automatic redirects for newer AWS opt-in regions (e.g. `eu-central-2`). Use the regional endpoint format to ensure compatibility across all supported regions.

## What does this PR do?

Installing the stack module in newer AWS opt-in regions (e.g. `eu-central-2`) fails with:
```
Error: Resource postcondition failed 
│ IllegalLocationConstraintException: The eu-central-2 location constraint
│ is incompatible for the region specific endpoint this request was sent to.
│ Unable to retrieve manifest
```

Older AWS regions silently handle this via a 307 redirect to the regional endpoint. Newer opt-in regions (`eu-central-2`, `mx-central-1`, etc.) do not support this legacy redirect behavior and return an error instead.

## Fix

Switch to the regional endpoint format, consistent with how the `aws-sam-apps` Makefile already constructs URLs in its `sam-pull` verification:

## Testing

Verified assets are accessible for all supported regions using the regional endpoint format, including `eu-central-2`.