### PR TITLE
ci: fix CloudTrail cleanup step failing when no trails exist

### DIFF
--- a/.github/workflows/cleanup-orphaned-resources.yaml
+++ b/.github/workflows/cleanup-orphaned-resources.yaml
@@ -31,7 +31,7 @@ jobs:
         }
 
         trail_arns=$(aws cloudtrail describe-trails --no-include-shadow-trails \
-          --query 'trailList[*].TrailARN' --output text | tr '\t' '\n' | grep -v '^None$')
+          --query 'trailList[*].TrailARN' --output text | tr '\t' '\n' | grep -v '^None$' || true)
         [[ -z "$trail_arns" ]] && echo "No trails found" && exit 0
 
         for arn in $trail_arns; do


### PR DESCRIPTION
## Summary

- With \`set -uo pipefail\` (and \`bash -e\` from Actions), \`grep\` exits 1 when it finds no matching lines. In the CloudTrail step this propagated through the pipeline assignment, killing the step before the empty-string guard on the next line could run.
- All 7 subsequent cleanup steps (SQS, CloudWatch, Lambda, SNS, Firehose, EventBridge, event source mappings) were also silently skipped as a result.
- Fix adds \`|| true\` to the CloudTrail grep pipeline — consistent with every other step in the workflow, all of which already had it.

Fixes: https://github.com/observeinc/terraform-aws-collection/actions/runs/28565347361

## Test plan

- [x] Reproduced the failure locally with \`bash -e\` (matching Actions execution model) — exits 1 without the fix
- [x] Confirmed fix exits 0 with "No trails found" when there are no trails
- [x] Confirmed fix correctly reaches the loop body when a real ARN is present