### PR TITLE
feat: add mock test paradigm with public CI support

### DIFF
--- a/.github/workflows/tests-mock-comment.yaml
+++ b/.github/workflows/tests-mock-comment.yaml
@@ -1,0 +1,82 @@
+name: Post Mock Test Comment
+
+on:
+  workflow_run:
+    workflows: ["Mock Tests"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Only comment when the triggering event was a pull_request
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download summary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mock-test-summary
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Build comment body
+        run: |
+          PR_NUMBER=$(cat pr-number.txt)
+          RUN_URL=$(cat run-url.txt)
+          OVERALL=$(cat overall-status.txt)
+
+          if [ "$OVERALL" = "success" ]; then
+            HEADLINE="✅ All mock tests passed"
+          else
+            HEADLINE="❌ Some mock tests failed"
+          fi
+
+          {
+            echo "<!-- mock-test-results -->"
+            echo "## Mock Test Results — ${HEADLINE}"
+            echo ""
+            echo "| Module / Example | Result |"
+            echo "|:---|:---|"
+            sort result_*.txt | while IFS='|' read -r dir icon summary; do
+              echo "| \`${dir}\` | ${icon} ${summary} |"
+            done
+            echo ""
+            echo "[View full run](${RUN_URL})"
+          } > comment.md
+
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Find existing comment
+        id: find_comment
+        run: |
+          COMMENT_ID=$(gh api \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(
+              .user.login == "github-actions[bot]" and
+              (.body | contains("<!-- mock-test-results -->"))
+            )] | first | .id // ""')
+          echo "comment_id=${COMMENT_ID}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update existing comment
+        if: steps.find_comment.outputs.comment_id != ''
+        run: |
+          jq -Rs '{body: .}' comment.md | \
+            gh api "repos/${{ github.repository }}/issues/comments/${{ steps.find_comment.outputs.comment_id }}" \
+              --method PATCH \
+              --input -
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create new comment
+        if: steps.find_comment.outputs.comment_id == ''
+        run: |
+          jq -Rs '{body: .}' comment.md | \
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --input -
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-mock.yaml
+++ b/.github/workflows/tests-mock.yaml
@@ -1,0 +1,104 @@
+name: Mock Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - $default-branch
+
+jobs:
+  prepare_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find_mock_dirs.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup the test matrix
+        id: find_mock_dirs
+        run: |
+          echo "matrix=$( find . -type d -name mock_tests -print | sed 's:/[^/]*$::' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+  test-mock:
+    runs-on: ubuntu-latest
+    needs: [prepare_matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        testdir: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v2.1.0
+        with:
+          directory: ${{ matrix.testdir }}
+
+      - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
+        uses: hashicorp/setup-terraform@v4.0.1
+        with:
+          terraform_version: ${{ steps.minMax.outputs.minVersion }}
+
+      - name: Mock test for ${{ matrix.testdir }}
+        id: run_tests
+        continue-on-error: true
+        run: |
+          DIR=${{ matrix.testdir }} make test-mock-dir 2>&1 \
+            | sed 's/\x1b\[[0-9;]*m//g' \
+            | tee test-output.txt
+          exit ${PIPESTATUS[0]}
+        env:
+          TF_VAR_test_run_id: ${{ github.run_id }}
+
+      - name: Save result
+        if: always()
+        run: |
+          SUMMARY=$(grep -E "^(Success|Failure)!" test-output.txt | tail -1 || echo "no output captured")
+          STATUS="${{ steps.run_tests.outcome }}"
+          ICON=$( [ "$STATUS" = "success" ] && echo "✅" || echo "❌" )
+          SAFE=$(echo "${{ matrix.testdir }}" | tr '/.' '_')
+          echo "${{ matrix.testdir }}|${ICON}|${SUMMARY}" > "result_${SAFE}.txt"
+
+      - name: Set artifact name
+        if: always()
+        id: artifact
+        run: |
+          echo "name=mock-result-$(echo '${{ matrix.testdir }}' | tr '/.' '-')" >> $GITHUB_OUTPUT
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: result_*.txt
+
+  summarize:
+    runs-on: ubuntu-latest
+    needs: [test-mock]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: mock-result-*
+          merge-multiple: true
+
+      - name: Write PR metadata
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" > run-url.txt
+          echo "${{ needs.test-mock.result }}" > overall-status.txt
+
+      - name: Upload summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mock-test-summary
+          path: |
+            result_*.txt
+            pr-number.txt
+            run-url.txt
+            overall-status.txt
+          retention-days: 1
+          overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@
 test-dir:
 	terraform -chdir=${DIR} init -upgrade
 	terraform -chdir=${DIR} test
+
+test-mock-dir:
+	terraform -chdir=${DIR} init -upgrade -test-directory=mock_tests
+	terraform -chdir=${DIR} test -test-directory=mock_tests

--- a/examples/forwarder-kms/mock_tests/example.tftest.hcl
+++ b/examples/forwarder-kms/mock_tests/example.tftest.hcl
@@ -1,0 +1,14 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+mock_provider "observe" {
+  source = "../../modules/testing/observe_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/forwarder-s3/mock_tests/example.tftest.hcl
+++ b/examples/forwarder-s3/mock_tests/example.tftest.hcl
@@ -1,0 +1,10 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/forwarder-sns/mock_tests/example.tftest.hcl
+++ b/examples/forwarder-sns/mock_tests/example.tftest.hcl
@@ -1,0 +1,10 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/logwriter-auto-subscription/mock_tests/example.tftest.hcl
+++ b/examples/logwriter-auto-subscription/mock_tests/example.tftest.hcl
@@ -1,0 +1,10 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/logwriter-manual-subscription/mock_tests/example.tftest.hcl
+++ b/examples/logwriter-manual-subscription/mock_tests/example.tftest.hcl
@@ -1,0 +1,10 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/simple/mock_tests/simple.tftest.hcl
+++ b/examples/simple/mock_tests/simple.tftest.hcl
@@ -1,0 +1,10 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+run "install" {
+  variables {
+    observe_customer = "1"
+    observe_token    = "dskey:secret"
+  }
+}

--- a/examples/stack-filedrop/mock_tests/example.tftest.hcl
+++ b/examples/stack-filedrop/mock_tests/example.tftest.hcl
@@ -1,0 +1,14 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+mock_provider "observe" {
+  source = "../../modules/testing/observe_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/examples/stack-http/mock_tests/example.tftest.hcl
+++ b/examples/stack-http/mock_tests/example.tftest.hcl
@@ -1,0 +1,14 @@
+mock_provider "aws" {
+  source = "../../modules/testing/aws_mock"
+}
+
+mock_provider "http" {
+  source = "../../modules/testing/http_mock"
+}
+
+mock_provider "observe" {
+  source = "../../modules/testing/observe_mock"
+}
+
+# only verifies module can be installed and removed correctly
+run "install" {}

--- a/modules/config/mock_tests/config.tftest.hcl
+++ b/modules/config/mock_tests/config.tftest.hcl
@@ -1,0 +1,26 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "default_include_all" {
+  command = plan
+  variables {
+    name   = "some-test"
+    bucket = "my-example-test"
+  }
+}
+
+run "test_mutually_exclusive_args" {
+  command = plan
+  variables {
+    name   = "some-test"
+    bucket = "my-example-test"
+
+    include_resource_types = ["AWS::EC2::Hohoho"]
+    exclude_resource_types = ["AWS::EC2::Instance"]
+  }
+
+  expect_failures = [
+    aws_config_configuration_recorder.this
+  ]
+}

--- a/modules/configsubscription/mock_tests/configsubscription.tftest.hcl
+++ b/modules/configsubscription/mock_tests/configsubscription.tftest.hcl
@@ -1,0 +1,30 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+
+  variables {
+    id_length = 50
+  }
+}
+
+run "create_sqs" {
+  module {
+    source = "../testing/sqs_queue"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+run "install" {
+  variables {
+    name_prefix = run.setup.short
+    target_arn  = run.create_sqs.queue.arn
+  }
+}

--- a/modules/externalrole/mock_tests/externalrole.tftest.hcl
+++ b/modules/externalrole/mock_tests/externalrole.tftest.hcl
@@ -1,0 +1,20 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+}
+
+run "install" {
+  variables {
+    name                   = run.setup.id
+    observe_aws_account_id = "158067661102"
+    datastream_ids         = ["4100001"]
+    allowed_actions = [
+      "cloudwatch:ListMetrics",
+    ]
+  }
+}

--- a/modules/forwarder/mock_tests/forwarder.tftest.hcl
+++ b/modules/forwarder/mock_tests/forwarder.tftest.hcl
@@ -1,0 +1,54 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+variables {
+  override_match        = "example"
+  override_content_type = "application/x-csv;delimiter=space"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+}
+
+run "create_bucket" {
+  module {
+    source = "../testing/s3_bucket"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+run "install_forwarder" {
+  variables {
+    name     = run.setup.id
+    code_uri = "s3://mock-bucket/mock-key"
+    destination = {
+      bucket = run.create_bucket.id
+    }
+    source_bucket_names = [for source in ["sns", "sqs", "eventbridge"] : "${run.setup.short}-${source}"]
+    source_topic_arns   = ["arn:aws:sns:${run.setup.region}:${run.setup.account_id}:*"]
+    content_type_overrides = [
+      {
+        pattern      = var.override_match
+        content_type = var.override_content_type
+      }
+    ]
+  }
+}
+
+run "update_forwarder" {
+  variables {
+    name     = run.setup.id
+    code_uri = "s3://mock-bucket/mock-key"
+    destination = {
+      uri = "https://localhost:8080"
+    }
+    source_bucket_names = [for source in ["sns", "sqs", "eventbridge"] : "${run.setup.short}-${source}"]
+    source_topic_arns   = ["arn:aws:sns:${run.setup.region}:${run.setup.account_id}:*"]
+  }
+}

--- a/modules/forwarder/mock_tests/validation.tftest.hcl
+++ b/modules/forwarder/mock_tests/validation.tftest.hcl
@@ -1,0 +1,94 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+variables {
+  name = "test"
+  destination = {
+    bucket = "bucket-name"
+  }
+  source_bucket_names = ["*", "a-b-c-", "a31asf"]
+  source_topic_arns   = ["arn:aws:sns:us-west-2:123456789012:my-topic-name"]
+  source_kms_key_arns = ["arn:aws:kms:us-west-2:123456789012:key/abcd1234-ab12-cd34-ef56-abcdef123456"]
+
+  content_type_overrides = [
+    {
+      pattern      = ".*"
+      content_type = "application/json"
+    }
+  ]
+}
+
+run "valid_canned_variables" {
+  command = plan
+}
+
+run "invalid_uri_scheme" {
+  command         = plan
+  expect_failures = [var.destination]
+
+  variables {
+    destination = {
+      uri = "ftp://foo"
+    }
+  }
+}
+
+run "mutually_exclusive_uri_and_bucket" {
+  command         = plan
+  expect_failures = [var.destination]
+
+  variables {
+    destination = {
+      uri    = "https://foo.com"
+      bucket = "foo.com"
+    }
+  }
+}
+
+run "invalid_source_bucket_name" {
+  command         = plan
+  expect_failures = [var.source_bucket_names]
+
+  variables {
+    source_bucket_names = ["a*c"]
+  }
+}
+
+run "source_bucket_arn" {
+  command         = plan
+  expect_failures = [var.source_bucket_names]
+
+  variables {
+    source_bucket_names = ["arn:s3:::hello-world"]
+  }
+}
+
+run "invalid_source_topic_arn" {
+  command         = plan
+  expect_failures = [var.source_topic_arns]
+
+  variables {
+    source_topic_arns = ["foo"]
+  }
+}
+
+run "invalid_source_kms_key_arn" {
+  command         = plan
+  expect_failures = [var.source_kms_key_arns]
+
+  variables {
+    source_kms_key_arns = ["foo"]
+  }
+}
+
+run "invalid_destination_bucket" {
+  command         = plan
+  expect_failures = [var.destination]
+
+  variables {
+    destination = {
+      bucket = "s3://foo"
+    }
+  }
+}

--- a/modules/logwriter/mock_tests/logwriter.tftest.hcl
+++ b/modules/logwriter/mock_tests/logwriter.tftest.hcl
@@ -1,0 +1,37 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+}
+
+run "create_bucket" {
+  module {
+    source = "../testing/s3_bucket"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+run "install_logwriter" {
+  variables {
+    name                            = run.setup.short
+    bucket_arn                      = run.create_bucket.arn
+    code_uri                        = "s3://mock-bucket/mock-key"
+    discovery_rate                  = "10 minutes"
+    filter_name                     = "${run.setup.id}-filter"
+    log_group_name_patterns         = ["${run.setup.short}"]
+    exclude_log_group_name_patterns = ["^noisy-group"]
+    debug_endpoint                  = "http://localhost:8080"
+  }
+
+  assert {
+    condition     = output.subscriber != null
+    error_message = "subscriber should be created when patterns are set"
+  }
+}

--- a/modules/metricstream/mock_tests/metricstream.tftest.hcl
+++ b/modules/metricstream/mock_tests/metricstream.tftest.hcl
@@ -1,0 +1,47 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+}
+
+run "create_bucket" {
+  module {
+    source = "../testing/s3_bucket"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+run "install" {
+  variables {
+    name       = run.setup.id
+    bucket_arn = run.create_bucket.arn
+    # Provide explicit filters to bypass sam_asset HTTP fetch for recommended filters
+    include_filters = []
+  }
+}
+
+run "update_filters" {
+  variables {
+    name       = run.setup.id
+    bucket_arn = run.create_bucket.arn
+    include_filters = [
+      {
+        namespace    = "AWS/RDS"
+        metric_names = []
+      },
+      {
+        namespace = "AWS/EC2"
+        metric_names = [
+          "DiskWriteBytes",
+        ]
+      },
+    ]
+  }
+}

--- a/modules/stack/mock_tests/collection.tftest.hcl
+++ b/modules/stack/mock_tests/collection.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+
+  variables {
+    id_length = 50
+  }
+}
+
+run "create_bucket" {
+  module {
+    source = "../testing/s3_bucket"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+run "install" {
+  variables {
+    name = run.setup.id
+    destination = {
+      arn    = run.create_bucket.access_point.arn
+      bucket = run.create_bucket.access_point.alias
+      prefix = ""
+    }
+
+    forwarder = {
+      code_uri = "s3://mock-bucket/mock-key"
+    }
+
+    configsubscription = {
+      delivery_bucket_name = run.create_bucket.access_point.bucket
+    }
+
+    config = {
+      include_resource_types = ["*"]
+    }
+
+    logwriter = {
+      log_group_name_patterns         = ["*"]
+      exclude_log_group_name_patterns = ["^/aws/elasticbeanstalk"]
+      lambda_timeout                  = 600
+      code_uri                        = "s3://mock-bucket/mock-key"
+      # Disable provisioners that require the AWS CLI on the Terraform runner
+      wait_for_discovery_on_apply = false
+      cleanup_on_destroy          = false
+    }
+
+    metricstream = {
+      include_filters = [
+        {
+          namespace = "AWS/RDS"
+        }
+      ]
+    }
+  }
+}

--- a/modules/subscriber/mock_tests/subscriber.tftest.hcl
+++ b/modules/subscriber/mock_tests/subscriber.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "aws" {
+  source = "../testing/aws_mock"
+}
+
+run "setup" {
+  module {
+    source = "../testing/setup"
+  }
+}
+
+run "create_bucket" {
+  module {
+    source = "../testing/s3_bucket"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+# Verify the subscriber module installs and exposes expected outputs
+run "install_subscriber" {
+  variables {
+    name                    = run.setup.short
+    code_uri                = "s3://mock-bucket/mock-key"
+    bucket_arn              = run.create_bucket.arn
+    destination_iam_arn     = "arn:aws:iam::123456789012:role/mock-destination-role"
+    firehose_arn            = "arn:aws:firehose:us-east-1:123456789012:deliverystream/mock-stream"
+    log_group_name_patterns = ["/test/${run.setup.short}"]
+  }
+
+  assert {
+    condition     = output.function_arn != null
+    error_message = "function_arn should be set"
+  }
+}
+
+# Verify updating patterns works
+run "update_subscriber" {
+  variables {
+    name                    = run.setup.short
+    code_uri                = "s3://mock-bucket/mock-key"
+    bucket_arn              = run.create_bucket.arn
+    destination_iam_arn     = "arn:aws:iam::123456789012:role/mock-destination-role"
+    firehose_arn            = "arn:aws:firehose:us-east-1:123456789012:deliverystream/mock-stream"
+    log_group_name_patterns = ["/test/${run.setup.short}/other"]
+  }
+}

--- a/modules/testing/aws_mock/aws.tfmock.hcl
+++ b/modules/testing/aws_mock/aws.tfmock.hcl
@@ -1,0 +1,132 @@
+mock_data "aws_caller_identity" {
+  defaults = {
+    account_id = "123456789012"
+    arn        = "arn:aws:iam::123456789012:user/mock"
+    user_id    = "AIDAIOSFODNN7EXAMPLE"
+  }
+}
+
+mock_data "aws_region" {
+  defaults = {
+    name        = "us-east-1"
+    region      = "us-east-1"
+    description = "US East (N. Virginia)"
+    id          = "us-east-1"
+  }
+}
+
+mock_data "aws_partition" {
+  defaults = {
+    partition  = "aws"
+    dns_suffix = "amazonaws.com"
+    id         = "aws"
+  }
+}
+
+# Used by modules/config for the managed Config service role
+mock_data "aws_iam_policy" {
+  defaults = {
+    arn    = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+    id     = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+    name   = "AWS_ConfigRole"
+    path   = "/service-role/"
+    policy = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+  }
+}
+
+mock_data "aws_iam_account_alias" {
+  defaults = {
+    account_alias = "mock-account"
+  }
+}
+
+# aws_iam_role validates that assume_role_policy is valid JSON.
+# Provide a minimal valid policy so mocked aws_iam_role resources don't fail
+# the client-side JSON check.
+mock_data "aws_iam_policy_document" {
+  defaults = {
+    json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+  }
+}
+
+# Resources whose .arn is passed to other resources' ARN-validated attributes
+# (e.g. aws_lambda_function.role, aws_cloudwatch_event_target.arn) must have
+# properly formatted ARNs — the AWS provider validates these client-side even
+# during mock apply.
+
+mock_resource "aws_iam_role" {
+  defaults = {
+    arn       = "arn:aws:iam::123456789012:role/mock-role"
+    unique_id = "AIDAIOSFODNN7EXAMPLE"
+  }
+}
+
+mock_resource "aws_sqs_queue" {
+  defaults = {
+    arn = "arn:aws:sqs:us-east-1:123456789012:mock-queue"
+    id  = "https://sqs.us-east-1.amazonaws.com/123456789012/mock-queue"
+    url = "https://sqs.us-east-1.amazonaws.com/123456789012/mock-queue"
+  }
+}
+
+mock_resource "aws_lambda_function" {
+  defaults = {
+    arn           = "arn:aws:lambda:us-east-1:123456789012:function:mock-function"
+    qualified_arn = "arn:aws:lambda:us-east-1:123456789012:function:mock-function:$LATEST"
+    invoke_arn    = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:mock-function/invocations"
+  }
+}
+
+mock_resource "aws_cloudwatch_log_group" {
+  defaults = {
+    arn = "arn:aws:logs:us-east-1:123456789012:log-group:mock-log-group"
+  }
+}
+
+mock_resource "aws_kinesis_firehose_delivery_stream" {
+  defaults = {
+    arn = "arn:aws:firehose:us-east-1:123456789012:deliverystream/mock-stream"
+  }
+}
+
+mock_resource "aws_sns_topic" {
+  defaults = {
+    arn = "arn:aws:sns:us-east-1:123456789012:mock-topic"
+  }
+}
+
+mock_resource "aws_s3_bucket" {
+  defaults = {
+    arn    = "arn:aws:s3:::mock-bucket"
+    bucket = "mock-bucket"
+    id     = "mock-bucket"
+  }
+}
+
+mock_resource "aws_s3_access_point" {
+  defaults = {
+    arn    = "arn:aws:s3:us-east-1:123456789012:accesspoint/mock-access-point"
+    alias  = "mock-access-point-123456789012-s3alias"
+    bucket = "mock-bucket"
+  }
+}
+
+mock_resource "aws_kms_key" {
+  defaults = {
+    arn    = "arn:aws:kms:us-east-1:123456789012:key/mock-key-id"
+    key_id = "mock-key-id"
+  }
+}
+
+mock_resource "aws_iam_policy" {
+  defaults = {
+    arn = "arn:aws:iam::123456789012:policy/mock-policy"
+    id  = "arn:aws:iam::123456789012:policy/mock-policy"
+  }
+}
+
+mock_resource "aws_cloudwatch_event_rule" {
+  defaults = {
+    arn = "arn:aws:events:us-east-1:123456789012:rule/mock-rule"
+  }
+}

--- a/modules/testing/http_mock/http.tfmock.hcl
+++ b/modules/testing/http_mock/http.tfmock.hcl
@@ -1,0 +1,24 @@
+# Mock response for sam_asset data "http" calls.
+#
+# response_body must be valid YAML that satisfies all SAM asset consumers:
+#   - forwarder.yaml   → Resources.Forwarder.Properties.CodeUri
+#   - logwriter.yaml   → Resources.Subscriber.Properties.CodeUri
+#   - recommended.yaml → IncludeFilters / ExcludeFilters (only when no explicit filters are passed)
+#
+# status_code = 200 is required to satisfy the lifecycle postcondition in sam_asset.
+mock_data "http" {
+  defaults = {
+    status_code = 200
+    response_body = <<-YAML
+      Resources:
+        Forwarder:
+          Properties:
+            CodeUri: s3://mock-bucket/mock-key
+        Subscriber:
+          Properties:
+            CodeUri: s3://mock-bucket/mock-key
+      IncludeFilters: []
+      ExcludeFilters: []
+    YAML
+  }
+}


### PR DESCRIPTION
Introduces a complete mock-based Terraform test suite that runs without AWS credentials, enabling tests to pass on public PRs from forks.

Key additions:
- `modules/testing/aws_mock/`: shared mock_provider for AWS data sources (caller_identity, region, partition, iam_policy_document) and resources with ARN-validated fields (iam_role, sqs_queue, lambda_function, etc.)
- `modules/testing/http_mock/`: shared mock for sam_asset HTTP manifest fetches, returning valid YAML covering all Lambda code URI consumers
- `mock_tests/` directories in all 8 modules and 8 examples, each using mock_provider "aws" (and "http"/"observe" where needed), bypassing real provider calls entirely
- `.github/workflows/tests-mock.yaml`: runs the mock suite on every PR (including forks) with no secrets required; captures per-job results as artifacts and uploads a summary for the comment workflow
- `.github/workflows/tests-mock-comment.yaml`: triggered via workflow_run to safely post/update a sticky PR comment with a results table, even for fork PRs where the test workflow has no write permissions
- `Makefile`: adds test-mock-dir target (passes -test-directory=mock_tests to both terraform init and terraform test)